### PR TITLE
Support for post subscriptions

### DIFF
--- a/app/assets/javascripts/answerbox/comment.coffee
+++ b/app/assets/javascripts/answerbox/comment.coffee
@@ -39,6 +39,9 @@ $(document).on "keyup", "input[name=ab-comment-new]", (evt) ->
           input.val ''
           ctr.html 160
           $("span#ab-comment-count-#{aid}").html data.count
+          subs = $("a[data-action=ab-submarine][data-a-id=#{aid}]")[0]
+          subs.dataset.torpedo = "no"
+          subs.children[0].nextSibling.textContent = "Unsubscribe"
         showNotification data.message, data.success
       error: (jqxhr, status, error) ->
         console.log jqxhr, status, error

--- a/app/assets/javascripts/answerbox/subscribe.coffee
+++ b/app/assets/javascripts/answerbox/subscribe.coffee
@@ -1,0 +1,27 @@
+# the laziest coding known to man
+$(document).on "click", "a[data-action=ab-submarine]", (ev) ->
+  ev.preventDefault()
+  btn = $(this)
+  aid = btn[0].dataset.aId
+  torpedo = 0
+  if btn[0].dataset.torpedo == "yes"
+    torpedo = 1
+  endpoint = "subscribe"
+  if torpedo == 0
+    endpoint = "un" + endpoint
+  $.ajax
+    url: '/ajax/' + endpoint # TODO: find a way to use rake routes instead of hardcoding them here
+    type: 'POST'
+    data:
+      answer: aid
+    success: (data, status, jqxhr) ->
+      if data.success
+        btn[0].dataset.torpedo = ["yes", "no"][torpedo]
+        btn[0].children[0].nextSibling.textContent = ["Subscribe", "Unsubscribe"][torpedo]
+        showNotification "Successfully " + endpoint + "d.", true
+      else
+        showNotification "Couldn't unsubscribe from the answer.", false
+    error: (jqxhr, status, error) ->
+      console.log jqxhr, status, error
+      showNotification "An error occurred, a developer should check the console for details", false
+    complete: (jqxhr, status) ->

--- a/app/controllers/ajax/subscription_controller.rb
+++ b/app/controllers/ajax/subscription_controller.rb
@@ -1,0 +1,19 @@
+class Ajax::SubscriptionController < ApplicationController
+  before_filter :authenticate_user!
+
+  def subscribe
+    params.require :answer
+    @status = 418
+    @message = "418 I'm a torpedo"
+    state = Subscription.subscribe(current_user, Answer.find(params[:answer])).nil?
+    @success = state == false
+  end
+
+  def unsubscribe
+    params.require :answer
+    @status = 418
+    @message = "418 I'm a torpedo"
+    state = Subscription.unsubscribe(current_user, Answer.find(params[:answer])).nil?
+    @success = state == false
+  end
+end

--- a/app/helpers/subscribe_helper.rb
+++ b/app/helpers/subscribe_helper.rb
@@ -1,0 +1,2 @@
+module SubscribeHelper
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -3,11 +3,13 @@ class Answer < ActiveRecord::Base
   belongs_to :question
   has_many :comments, dependent: :destroy
   has_many :smiles, dependent: :destroy
+  has_many :subscriptions, dependent: :destroy
 
   after_create do
     Inbox.where(user: self.user, question: self.question).destroy_all
 
     Notification.notify self.question.user, self unless self.question.author_is_anonymous
+    Subscription.subscribe self.user, self
     self.user.increment! :answered_count
     self.question.increment! :answer_count
   end
@@ -27,9 +29,10 @@ class Answer < ActiveRecord::Base
     end
     self.comments.each do |comment|
       comment.user.decrement! :commented_count
-      Notification.denotify self.user, comment
+      Subscription.denotify comment, self
     end
     Notification.denotify self.question.user, self
+    Subscription.destruct self
   end
 
   def notification_type(*_args)

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -10,6 +10,7 @@ class Answer < ActiveRecord::Base
 
     Notification.notify self.question.user, self unless self.question.author_is_anonymous
     Subscription.subscribe self.user, self
+    Subscription.subscribe self.question.user, self
     self.user.increment! :answered_count
     self.question.increment! :answer_count
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,7 +7,7 @@ class Comment < ActiveRecord::Base
   validates :content, length: { maximum: 160 }
 
   after_create do
-    Subscription.subscribe self.user, answer
+    Subscription.subscribe self.user, answer, false
     Subscription.notify self, answer
     user.increment! :commented_count
     answer.increment! :comment_count

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,14 +7,15 @@ class Comment < ActiveRecord::Base
   validates :content, length: { maximum: 160 }
 
   after_create do
-    Notification.notify answer.user, self unless answer.user == self.user
+    Subscription.subscribe self.user, answer
+    Subscription.notify self, answer
     user.increment! :commented_count
     answer.increment! :comment_count
   end
 
   before_destroy do
-    Notification.denotify answer.user, self unless answer.user == self.user
-    user.decrement! :commented_count
+    Subscription.denotify self, answer
+    user.decrement!  :commented_count
     answer.decrement! :comment_count
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,48 @@
+class Subscription < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :answer
+
+  class << self
+    def subscribe(recipient, target)
+      if Subscription.find_by(user: recipient, answer: target).nil?
+        Subscription.new(user: recipient, answer: target).save!
+      end
+    end
+
+    def unsubscribe(recipient, target)
+      if recipient.nil? or target.nil?
+        return nil
+      end
+
+      subs = Subscription.find_by(user: recipient, answer: target)
+      subs.destroy unless subs.nil?
+    end
+
+    def destruct(target)
+      if target.nil?
+        return nil
+      end
+      Subscription.where(answer: target).destroy_all
+    end
+
+    def notify(source, target)
+      if source.nil? or target.nil?
+        return nil
+      end
+
+      Subscription.where(answer: target).each do |subs|
+        next unless not subs.user == source.user
+        Notification.notify subs.user, source
+      end
+    end
+
+    def denotify(source, target)
+      if source.nil? or target.nil?
+        return nil
+      end
+      Subscription.where(answer: target).each do |subs|
+        Notification.denotify subs.user, source
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,8 @@ class User < ActiveRecord::Base
   has_many :groups, dependent: :destroy
   has_many :group_memberships, class_name: "GroupMember", foreign_key: 'user_id', dependent: :destroy
 
+  has_many :subscriptions, dependent: :destroy
+
   SCREEN_NAME_REGEX = /\A[a-zA-Z0-9_]{1,16}\z/
   WEBSITE_REGEX = /https?:\/\/([A-Za-z.\-]+)\/?(?:.*)/i
 

--- a/app/views/ajax/subscription/subscribe.json.jbuilder
+++ b/app/views/ajax/subscription/subscribe.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'ajax/shared/status'

--- a/app/views/ajax/subscription/unsubscribe.json.jbuilder
+++ b/app/views/ajax/subscription/unsubscribe.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'ajax/shared/status'

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -53,7 +53,13 @@
           %p.notification--text
             commented on
             %a{href: show_user_answer_path(username: notification.target.user.screen_name, id: notification.target.answer.id), title: "#{notification.target.answer.content[0..40]}...", data: { toggle: :tooltip, placement: :top }}
-              your answer
+              - if notification.target.answer.user == current_user
+                your
+              - elsif notification.target.user == notification.target.answer.user
+                their
+              - else
+                = user_screen_name(notification.target.answer.user, false, false) + "'s"
+              answer
             %span{title: notification.target.created_at, data: { toggle: :tooltip, placement: :bottom }}
               = time_ago_in_words notification.target.created_at
             ago

--- a/app/views/shared/_answerbox_buttons.html.haml
+++ b/app/views/shared/_answerbox_buttons.html.haml
@@ -21,7 +21,7 @@
     %button.btn.btn-default.btn-sm.dropdown-toggle{data: { toggle: :dropdown }, aria: { expanded: :false }}
       %span.caret
     %ul.dropdown-menu.dropdown-menu-right{role: :menu}
-      - if a.subscriptions.find_by(user: current_user)
+      - if Subscription.is_subscribed(current_user, a)
         %li
           -#                                            fun joke    should subscribe?
           %a{href: '#', data: { a_id: a.id, action: 'ab-submarine', torpedo: "no" }}

--- a/app/views/shared/_answerbox_buttons.html.haml
+++ b/app/views/shared/_answerbox_buttons.html.haml
@@ -21,6 +21,17 @@
     %button.btn.btn-default.btn-sm.dropdown-toggle{data: { toggle: :dropdown }, aria: { expanded: :false }}
       %span.caret
     %ul.dropdown-menu.dropdown-menu-right{role: :menu}
+      - if a.subscriptions.find_by(user: current_user)
+        %li
+          -#                                            fun joke    should subscribe?
+          %a{href: '#', data: { a_id: a.id, action: 'ab-submarine', torpedo: "no" }}
+            %i.fa.fa-anchor
+            Unubscribe
+      - else
+        %li
+          %a{href: '#', data: { a_id: a.id, action: 'ab-submarine', torpedo: "yes" }}
+            %i.fa.fa-anchor
+            Subscribe
       - if privileged? a.user
         %li.text-danger
           %a{href: '#', data: { a_id: a.id, action: 'ab-destroy' }}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,8 @@ Rails.application.routes.draw do
     match '/destroy_group', to: 'group#destroy', via: :post, as: :destroy_group
     match '/group_membership', to: 'group#membership', via: :post, as: :group_membership
     match '/preview', to: "question#preview", via: :post, as: :preview
+    match '/subscribe', to: 'subscription#subscribe', via: :post, as: :subscribe_answer
+    match '/unsubscribe', to: 'subscription#unsubscribe', via: :post, as: :unsubscribe_answer
   end
 
   match '/public', to: 'public#index', via: :get, as: :public_timeline

--- a/db/migrate/20150420232305_create_subscriptions.rb
+++ b/db/migrate/20150420232305_create_subscriptions.rb
@@ -1,0 +1,10 @@
+class CreateSubscriptions < ActiveRecord::Migration
+  def change
+    create_table :subscriptions do |t|
+      t.integer :user_id, null: false
+      t.integer :answer_id, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150421120557_add_is_active_to_subscriptions.rb
+++ b/db/migrate/20150421120557_add_is_active_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :subscriptions, :is_active, :boolean, default: :true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150421120557) do
+ActiveRecord::Schema.define(version: 20150419201122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,49 +101,6 @@ ActiveRecord::Schema.define(version: 20150421120557) do
     t.datetime "updated_at"
   end
 
-  create_table "oauth_access_grants", force: :cascade do |t|
-    t.integer  "resource_owner_id", null: false
-    t.integer  "application_id",    null: false
-    t.string   "token",             null: false
-    t.integer  "expires_in",        null: false
-    t.text     "redirect_uri",      null: false
-    t.datetime "created_at",        null: false
-    t.datetime "revoked_at"
-    t.string   "scopes"
-  end
-
-  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
-
-  create_table "oauth_access_tokens", force: :cascade do |t|
-    t.integer  "resource_owner_id"
-    t.integer  "application_id"
-    t.string   "token",             null: false
-    t.string   "refresh_token"
-    t.integer  "expires_in"
-    t.datetime "revoked_at"
-    t.datetime "created_at",        null: false
-    t.string   "scopes"
-  end
-
-  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
-  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
-  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
-
-  create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",                      null: false
-    t.string   "uid",                       null: false
-    t.string   "secret",                    null: false
-    t.text     "redirect_uri",              null: false
-    t.string   "scopes",       default: "", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "owner_id"
-    t.string   "owner_type"
-  end
-
-  add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
-  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
-
   create_table "questions", force: :cascade do |t|
     t.string   "content"
     t.boolean  "author_is_anonymous"
@@ -198,25 +155,6 @@ ActiveRecord::Schema.define(version: 20150421120557) do
   add_index "smiles", ["answer_id"], name: "index_smiles_on_answer_id", using: :btree
   add_index "smiles", ["user_id", "answer_id"], name: "index_smiles_on_user_id_and_answer_id", unique: true, using: :btree
   add_index "smiles", ["user_id"], name: "index_smiles_on_user_id", using: :btree
-
-  create_table "subscriptions", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "answer_id"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
-    t.boolean  "is_active",  default: true
-  end
-
-  create_table "user_themes", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "bg",         default: "#fafafa"
-    t.string   "color",      default: "#5e35b1"
-    t.string   "color_a",    default: "#5e35b1"
-    t.string   "color_alt",  default: "#eeeeee"
-    t.string   "bg_primary", default: "#5e35b1"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-  end
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                             default: "",    null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150419201122) do
+ActiveRecord::Schema.define(version: 20150421120557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,6 +101,49 @@ ActiveRecord::Schema.define(version: 20150419201122) do
     t.datetime "updated_at"
   end
 
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.integer  "resource_owner_id", null: false
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.integer  "expires_in",        null: false
+    t.text     "redirect_uri",      null: false
+    t.datetime "created_at",        null: false
+    t.datetime "revoked_at"
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.integer  "resource_owner_id"
+    t.integer  "application_id"
+    t.string   "token",             null: false
+    t.string   "refresh_token"
+    t.integer  "expires_in"
+    t.datetime "revoked_at"
+    t.datetime "created_at",        null: false
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.string   "name",                      null: false
+    t.string   "uid",                       null: false
+    t.string   "secret",                    null: false
+    t.text     "redirect_uri",              null: false
+    t.string   "scopes",       default: "", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "owner_id"
+    t.string   "owner_type"
+  end
+
+  add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
+
   create_table "questions", force: :cascade do |t|
     t.string   "content"
     t.boolean  "author_is_anonymous"
@@ -155,6 +198,25 @@ ActiveRecord::Schema.define(version: 20150419201122) do
   add_index "smiles", ["answer_id"], name: "index_smiles_on_answer_id", using: :btree
   add_index "smiles", ["user_id", "answer_id"], name: "index_smiles_on_user_id_and_answer_id", unique: true, using: :btree
   add_index "smiles", ["user_id"], name: "index_smiles_on_user_id", using: :btree
+
+  create_table "subscriptions", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "answer_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.boolean  "is_active",  default: true
+  end
+
+  create_table "user_themes", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "bg",         default: "#fafafa"
+    t.string   "color",      default: "#5e35b1"
+    t.string   "color_a",    default: "#5e35b1"
+    t.string   "color_alt",  default: "#eeeeee"
+    t.string   "bg_primary", default: "#5e35b1"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                             default: "",    null: false

--- a/spec/controllers/subscribe_controller_spec.rb
+++ b/spec/controllers/subscribe_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SubscribeController, :type => :controller do
+
+end

--- a/spec/helpers/subscribe_helper_spec.rb
+++ b/spec/helpers/subscribe_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SubscribeHelper. For example:
+#
+# describe SubscribeHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SubscribeHelper, :type => :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Subscription, :type => :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Fixes Retrospring/bugs#10
![screen shot 2015-04-21 at 6 04 59](https://cloud.githubusercontent.com/assets/614231/7243982/71cd375a-e7f2-11e4-87bb-b7326949f835.png)
![screen shot 2015-04-21 at 6 05 20](https://cloud.githubusercontent.com/assets/614231/7243983/71df6560-e7f2-11e4-8800-631e173261f6.png)

It adds a "Subscribe" and "Unsubscribe" option in the drop down dialog of answers, commenting automatically subscribes the commenter to the answer.

NOTE: This breaks ALL NEW comment notifications on existing answers AS IS, you need to run ``rake justask:fix_submarines`` to subscribe every user to their answers.

The reason behind this is that it used to notify the answer's owner, now it notifies everyone that is bound to the answer in the subscription record, since this is a new table nobody will be subscribed to any answers and ergo nobody gets notified for new comments on answers that were created prior to when this goes live, existing notifications still exist.

Trivia: 
Submarines came from "subs"-cription