### PR TITLE
Rename 'delete answer' to 'return to inbox' for clarity

### DIFF
--- a/app/assets/javascripts/answerbox/destroy.coffee
+++ b/app/assets/javascripts/answerbox/destroy.coffee
@@ -3,12 +3,13 @@ $(document).on "click", "a[data-action=ab-destroy]", (ev) ->
   btn = $(this)
   aid = btn[0].dataset.aId
   swal
-    title: "Really delete?"
-    text: "The question will be moved back to your inbox."
+    title: "Are you sure?"
+    text: "The question will be moved back to your inbox, but it won't delete any posts to social media."
     type: "warning"
     showCancelButton: true
     confirmButtonColor: "#DD6B55"
-    confirmButtonText: "Delete"
+    confirmButtonText: "Yes"
+    cancelButtonText: "No"
     closeOnConfirm: true
   , ->
     $.ajax

--- a/app/views/shared/_answerbox_buttons.html.haml
+++ b/app/views/shared/_answerbox_buttons.html.haml
@@ -36,7 +36,7 @@
         %li.text-danger
           %a{href: '#', data: { a_id: a.id, action: 'ab-destroy' }}
             %i.fa.fa-trash-o
-            Delete
+            Return to Inbox
       - unless a.user == current_user
         %li
           %a{href: '#', data: { a_id: a.id, action: 'ab-report' }}


### PR DESCRIPTION
Might make people aware you can actually kind of edit posts this way.