### PR TITLE
Allow loading markdown files from FS

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -14,4 +14,33 @@ module MarkdownHelper
     md = Redcarpet::Markdown.new(TwitteredMarkdown, MARKDOWN_OPTS)
     CGI.unescape_html(Sanitize.fragment(md.render(content), EVIL_TAGS)).strip
   end
+
+  def raw_markdown(content)
+    md = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+    raw md.render content
+  end
+
+  def get_markdown(path, relative_to = Rails.root)
+    begin
+      File.read relative_to.join(path)
+    rescue Errno::ENOENT
+      "# Error reading #{relative_to.join(path)}"
+    end
+  end
+
+  def markdown_io(path, relative_to = Rails.root)
+    markdown get_markdown path, relative_to
+  end
+
+  def strip_markdown_io(path, relative_to = Rails.root)
+    strip_markdown get_markdown path, relative_to
+  end
+
+  def twitter_markdown_io(path, relative_to = Rails.root)
+    twitter_markdown get_markdown path, relative_to
+  end
+
+  def raw_markdown_io(path, relative_to = Rails.root)
+    raw_markdown get_markdown path, relative_to
+  end
 end


### PR DESCRIPTION
![screen shot 2015-05-24 at 6 18 24](https://cloud.githubusercontent.com/assets/614231/7787902/7d634a14-0241-11e5-8fb4-c9c2c9ab7a24.png)

```haml
= markdown_io "README.md"
= twitter_markdown_io "README.md"
= strip_markdown_io "README.md"
= raw_markdown_io "README.md"
```

Requested by @pixeldesu 

Options
```ruby
markdown_io PATH, RELATIVE_ROOT
```

`RELATIVE_ROOT` is by default `Rails.root`

so `markdown_io "README.md"` renders `root/README.md` and `markdown_io "README.md" Rails.root.join "app/markdown"` renders "root/app/markdown/README.md", alternatively you can just call `markdown_io "app/markdown/README.md"`