### PR TITLE
Rename locale cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,8 +14,8 @@ class ApplicationController < ActionController::Base
     if params[:hl].nil?
       if current_user.present?
         I18n.locale = current_user.locale
-      elsif not cookies[:hl].nil?
-        I18n.locale = cookies[:hl]
+      elsif not cookies[:lang].nil?
+        I18n.locale = cookies[:lang]
       else
         I18n.locale = 'en'
       end
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    cookies[:hl] = I18n.locale #unless cookies[:allow_cookies].nil? # some EU cookie bullsh-
+    cookies[:lang] = I18n.locale #unless cookies[:allow_cookies].nil? # some EU cookie bullsh-
   end
 
   # check if user got hit by the banhammer of doom


### PR DESCRIPTION
This should switch most users back to english, everyone that set their language via `?hl=` still has it set due to it being saved in their account.

Alternatively it's to set everyone's User table `locale` column to `en` where it is `null`

The code that caused this issue is already dealt with.