### PR TITLE
Do not declare mobile app capability

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,9 +5,6 @@
     %meta{'http-equiv' => 'X-UA-Compatible' ,content: 'IE=edge'}
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1, user-scalable=no'}
     %meta{name: 'theme-color', content: '#5e35b1'}
-    %meta{name: "mobile-web-app-capable", content: "yes"}
-    %meta{name: "apple-mobile-web-app-capable", content: "yes"}
-    %meta{name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent'}
     %link{rel: 'apple-touch-icon', href: '/apple-touch-icon-precomposed.png'}
     %link{rel: 'icon', href: '/images/favicon/favicon-16.png', sizes: '16x16'}
     %link{rel: 'icon', href: '/icon-152.png', sizes: '152x152'}


### PR DESCRIPTION
I would love to have a Retrospring icon on my home screen, but as long as you are declaring it to be mobile app capable, I can't; mobile app capable websites are expected to implement their own navigation controls, but Retrospring's sole navigation is 'go back home'. When in Safari, I'll use the back swipe gesture all the time, especially when rolling through notifications. In mobile app mode, the back gesture (and the open in new tab button) does not exist, so reading notifications is a stressful experience involving tapping the menu every time and trying to remember which I have read and which I have not.

As a result of this, I can't put Retrospring on my home screen.
