### PR TITLE
Make avatar a link to profile

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -27,7 +27,7 @@
           - unless @user.nil?
             - unless @user == current_user
               %li.hidden-xs{"data-toggle" => "tooltip", "data-placement" => "bottom", title: t('views.actions.group')}
-                %a{href: '#', data: { target: "#modal-group-memberships", toggle: :modal }}
+                %a{href: show_user_profile_path(current_user.screen_name), data: { target: "#modal-group-memberships", toggle: :modal }}
                   %i.fa.fa-users.hidden-xs
                   %span.visible-xs= t('views.actions.group')
           = render "layouts/notifications"


### PR DESCRIPTION
Making this a link with an actual url instead of just '#' means that you
can middle click on your avatar in chrome to head over to your profile
in a new tab, without having to use its dropdown!

Assuming I edited your code properly, it shouldn't interfere with
anything. :3
