### PR TITLE
Fix profile links on new inbox entries being not visible

### DIFF
--- a/app/assets/stylesheets/components/_inbox-entry.scss
+++ b/app/assets/stylesheets/components/_inbox-entry.scss
@@ -6,6 +6,10 @@
       background-color: var(--primary);
       color: RGB(var(--primary-text));
 
+      a {
+        color: RGB(var(--primary-text));
+      }
+
       .text-muted {
         color: RGBA(var(--primary-text), 0.8) !important;
       }

--- a/app/views/inbox/_entry.html.haml
+++ b/app/views/inbox/_entry.html.haml
@@ -1,4 +1,4 @@
-.card.inbox-box{class: i.new? ? 'inbox-entry--new' : '', data: { id: i.id }}
+.card.inbox-entry{class: i.new? ? 'inbox-entry--new' : '', data: { id: i.id }}
   .card-header
     .media
       - unless i.question.author_is_anonymous


### PR DESCRIPTION
Reported by @mltnhm to me.

Fixed now:
![](https://desu.pictures/FluffyOrangeBabirusa8.png)

_Also used this to remove the now non-existent class `.inbox-box` from inbox entries._