### PR TITLE
Fix notification menu clipping out of view

### DIFF
--- a/app/views/navigation/main/_notifications.haml
+++ b/app/views/navigation/main/_notifications.haml
@@ -8,7 +8,7 @@
       %i.fa.fa-bell
     %span.sr-only Notifications
     %span.badge= notification_count
-  .dropdown-menu.notification-dropdown
+  .dropdown-menu.dropdown-menu-right.notification-dropdown
     - if notifications.count == 0
       .dropdown-item.text-center.p-2
         %i.fa.fa-bell-o.notification__bell-icon


### PR DESCRIPTION
Pretty self-explanatory. Fixes #96 since that is the issue it was actually reported for.