### PR TITLE
Use own hCaptcha fork to fix signups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'colorize'
 gem 'carrierwave', '~> 2.0'
 gem 'carrierwave_backgrounder', git: 'https://github.com/mltnhm/carrierwave_backgrounder.git'
 gem 'mini_magick'
-gem 'hcaptcha', git: 'https://github.com/firstmoversadvantage/hcaptcha.git'
+gem "hcaptcha", "~> 6.0", git: "https://github.com/Retrospring/hcaptcha.git", ref: "v6.0.2"
 
 gem "rolify", "~> 5.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,7 +542,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/Retrospring/hcaptcha.git
+  revision: 9feac4908097e3dc2afd6f08d07cbfbaa1073a1d
+  ref: v6.0.2
+  specs:
+    hcaptcha (6.0.2)
+      json
+
+GIT
   remote: https://github.com/amplifr/tumblr_client
   revision: 3927ee366598a9b70b095933ded32e45f730b652
   specs:
@@ -9,13 +17,6 @@ GIT
       mime-types
       oauth
       simple_oauth
-
-GIT
-  remote: https://github.com/firstmoversadvantage/hcaptcha.git
-  revision: 531ce4562dd3d29a52497bfe09378ba61a40c98a
-  specs:
-    hcaptcha (6.0.1)
-      json
 
 GIT
   remote: https://github.com/mltnhm/carrierwave_backgrounder.git
@@ -577,7 +578,7 @@ DEPENDENCIES
   guard-brakeman
   haml (~> 5.0)
   haml_lint
-  hcaptcha!
+  hcaptcha (~> 6.0)!
   httparty
   i18n-js (= 3.0.0.rc10)
   jbuilder (~> 2.10)


### PR DESCRIPTION
Apparently the hCaptcha response can be slightly larger than 4000 characters.

Related commit: https://github.com/Retrospring/hcaptcha/commit/50cca7ee1b8abe5117cfbf05740a03a61b2398e8