### PR TITLE
Fix broken services integration after omniauth bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,3 +97,5 @@ group :development, :test do
 end
 
 gem "webpacker", "~> 5.2"
+
+gem "omniauth-rails_csrf_protection", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,9 @@ GEM
     omniauth-oauth (1.2.0)
       oauth
       omniauth (>= 1.0, < 3)
+    omniauth-rails_csrf_protection (1.0.0)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     omniauth-tumblr (1.2)
       multi_json
       omniauth-oauth (~> 1.0)
@@ -596,6 +599,7 @@ DEPENDENCIES
   mini_magick
   newrelic_rpm
   omniauth
+  omniauth-rails_csrf_protection (~> 1.0)
   omniauth-tumblr
   omniauth-twitter
   pg

--- a/app/views/settings/_services.haml
+++ b/app/views/settings/_services.haml
@@ -7,7 +7,7 @@
 
     - APP_CONFIG['sharing'].each do |service, service_options|
       - if service_options['enabled'] && @services.none? { |x| x.provider == service.to_s }
-        %p= link_to t('views.settings.service.connect', service: service.capitalize), "/auth/#{service}"
+        %p= link_to t('views.settings.service.connect', service: service.capitalize), "/auth/#{service}", method: :post
 
   - if @services.count.positive?
     %ul.list-group


### PR DESCRIPTION
The last merged commit (45cb0cab26a818094767352d554e546ae22314b3) bumped omniauth to version `1.2.0` during the gemfile update breaking service integration for both Tumblr and Twitter.

https://github.com/Retrospring/retrospring/blob/45cb0cab26a818094767352d554e546ae22314b3/Gemfile.lock#L329

The cause is that omniauth `1.2.0` requires the gem `omniauth-rails_csrf_protection` and also forces the request to use only post methods as described here: https://stackoverflow.com/questions/66009147/no-route-matches-get-auth-twitter-omnia.

This commit adds the missing gem and changes the HTTP request used to link the service via omniauth to use POST instead of GET.