### PR TITLE
Fix list group text not being visible when the selected item is a link

### DIFF
--- a/app/assets/stylesheets/overrides/_list-group.scss
+++ b/app/assets/stylesheets/overrides/_list-group.scss
@@ -5,6 +5,10 @@
   &.active:hover {
     background-color: var(--primary);
     border-color: var(--primary);
+
+    a {
+      color: var(--primary-text);
+    }
   }
 }
 


### PR DESCRIPTION
Before:
<img width="846" alt="Screenshot 2021-08-11 at 21 33 02" src="https://user-images.githubusercontent.com/6197148/129091823-085c07a7-5cf8-4db2-9195-8f47f425d1a4.png">

After:
<img width="846" alt="Screenshot 2021-08-11 at 21 32 53" src="https://user-images.githubusercontent.com/6197148/129091833-33d2157e-7a87-4b7a-a5e5-79d48b890b98.png">
