### PR TITLE
Use `break-word` instead of `break-all`

### DIFF
--- a/app/assets/stylesheets/components/_answerbox.scss
+++ b/app/assets/stylesheets/components/_answerbox.scss
@@ -5,7 +5,7 @@
   &__answer-date {
     margin-bottom: 0;
     overflow: hidden;
-    word-break: break-all;
+    word-break: break-word;
   }
   
   &__answer-date {

--- a/app/assets/stylesheets/components/_comments.scss
+++ b/app/assets/stylesheets/components/_comments.scss
@@ -9,7 +9,7 @@
   &__user,
   &__content {
     margin-bottom: 0;
-    word-break: break-all;
+    word-break: break-word;
   }
 
   &__user-avatar {


### PR DESCRIPTION
This will prevent words being broken mid-word