### PR TITLE
Remove unused section from config

### DIFF
--- a/config/justask.yml.example
+++ b/config/justask.yml.example
@@ -38,18 +38,6 @@ sharing:
 # Redis
 redis_url: "redis://localhost:6379"
 
-# Site admins
-admins:
-  - screen_name: 'nilsding'
-    about_text: nilsding
-    subtext: Backend, Server & Code
-  - screen_name: 'pixeldesu'
-    about_text: pixeldesu
-    subtext: Frontend Design & Layout
-  - screen_name: 'Filippus'
-    about_text: Filippus
-    subtext: Moderator Management & Support
-
 # uncomment if using cloud storage
 # fog:
   # fog credentials


### PR DESCRIPTION
Found this while setting up the site for the other PR, this config section isn't used at all anymore and can thus be omitted