### PR TITLE
Add notice on registering about issues with Hotmail/Outlook

### DIFF
--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -11,6 +11,8 @@
 
             = f.text_field :screen_name, autofocus: true, label: t('views.settings.account.username')
             = f.email_field :email, autofocus: false, label: t('views.settings.account.email')
+            .alert.alert-danger
+              We're currently experiencing issues with Outlook/Hotmail addresses, please don't use those!
 
             = f.password_field :password, autocomplete: :off, label: t('views.settings.account.password')
             = f.password_field :password_confirmation, autocomplete: :off, label: t('views.settings.account.password_confirm')


### PR DESCRIPTION
A lot of people are registering with Outlook/Hotmail addresses now, and we're currently blocked by them so we have to manually intervene over Twitter.

This will, until we resolved the issue, warn users about using Hotmail/Outlook addresses!