### PR TITLE
Fix Tumblr sharing not working

### DIFF
--- a/app/models/services/tumblr.rb
+++ b/app/models/services/tumblr.rb
@@ -1,4 +1,5 @@
 class Services::Tumblr < Service
+  include Rails.application.routes.url_helpers
   include SocialHelper::TumblrMethods
 
   def provider

--- a/spec/helpers/social_helper/tumblr_methods_spec.rb
+++ b/spec/helpers/social_helper/tumblr_methods_spec.rb
@@ -8,6 +8,20 @@ describe SocialHelper::TumblrMethods, :type => :helper do
                                     content: 'aaaa',
                                     question_content: 'q') }
 
+  before do
+    stub_const("APP_CONFIG", {
+      'hostname' => 'example.com',
+      'anonymous_name' => 'Anonymous',
+      'https' => true,
+      'items_per_page' => 5,
+      'sharing' => {
+        'tumblr' => {
+          'consumer_key' => 'AAA',
+        }
+      }
+    })
+  end
+
   describe '#tumblr_title' do
     context 'Asker is anonymous' do
       subject { tumblr_title(answer) }
@@ -36,7 +50,7 @@ describe SocialHelper::TumblrMethods, :type => :helper do
     subject { tumblr_body(answer) }
 
     it 'should return a proper body' do
-      expect(subject).to eq("aaaa\n\n[Smile or comment on the answer here](https://justask.rrerr.net/#{answer.user.screen_name}/a/#{answer.id})")
+      expect(subject).to eq("aaaa\n\n[Smile or comment on the answer here](https://example.com/#{answer.user.screen_name}/a/#{answer.id})")
     end
   end
 
@@ -44,7 +58,7 @@ describe SocialHelper::TumblrMethods, :type => :helper do
     subject { tumblr_share_url(answer) }
 
     it 'should return a proper share link' do
-        expect(subject).to eq("https://www.tumblr.com/widgets/share/tool?shareSource=legacy&posttype=text&title=#{CGI.escape(tumblr_title(answer))}&url=#{CGI.escape("https://justask.rrerr.net/#{answer.user.screen_name}/a/#{answer.id}")}&caption=&content=#{CGI.escape(tumblr_body(answer))}")
+        expect(subject).to eq("https://www.tumblr.com/widgets/share/tool?shareSource=legacy&posttype=text&title=#{CGI.escape(tumblr_title(answer))}&url=#{CGI.escape("https://example.com/#{answer.user.screen_name}/a/#{answer.id}")}&caption=&content=#{CGI.escape(tumblr_body(answer))}")
     end
   end
 end

--- a/spec/helpers/social_helper/twitter_methods_spec.rb
+++ b/spec/helpers/social_helper/twitter_methods_spec.rb
@@ -8,12 +8,20 @@ describe SocialHelper::TwitterMethods, :type => :helper do
                                   content: 'a' * 255,
                                   question_content: 'q' * 255) }
 
+  before do
+    stub_const("APP_CONFIG", {
+      'hostname' => 'example.com',
+      'https' => true,
+      'items_per_page' => 5
+    })
+  end
+
   describe '#prepare_tweet' do
     context 'when the question and answer need to be shortened' do
       subject { prepare_tweet(answer) }
 
       it 'should return a properly formatted tweet' do
-        expect(subject).to eq("#{'q' * 123}… — #{'a' * 124}… https://justask.rrerr.net/#{user.screen_name}/a/#{answer.id}")
+        expect(subject).to eq("#{'q' * 123}… — #{'a' * 124}… https://example.com/#{user.screen_name}/a/#{answer.id}")
       end
     end
 
@@ -28,7 +36,7 @@ describe SocialHelper::TwitterMethods, :type => :helper do
       subject { prepare_tweet(answer) }
 
       it 'should return a properly formatted tweet' do
-        expect(subject).to eq("#{answer.question.content} — #{answer.content} https://justask.rrerr.net/#{user.screen_name}/a/#{answer.id}")
+        expect(subject).to eq("#{answer.question.content} — #{answer.content} https://example.com/#{user.screen_name}/a/#{answer.id}")
       end
     end
   end

--- a/spec/models/services/tumblr_spec.rb
+++ b/spec/models/services/tumblr_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Services::Tumblr do
+  describe "#post" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:service) { Services::Tumblr.create(user: user) }
+    let(:answer) { FactoryBot.create(:answer, user: user,
+                                     content: 'a' * 255,
+                                     question_content: 'q' * 255) }
+    let(:tumblr_client) { instance_double(Tumblr::Client) }
+
+    before do
+      allow(Tumblr::Client).to receive(:new).and_return(tumblr_client)
+      allow(tumblr_client).to receive(:text)
+      stub_const("APP_CONFIG", {
+        'hostname' => 'example.com',
+        'anonymous_name' => 'Anonymous',
+        'https' => true,
+        'items_per_page' => 5,
+        'sharing' => {
+          'tumblr' => {
+            'consumer_key' => 'AAA',
+          }
+        }
+      })
+    end
+    
+    it "posts a text-post" do
+      answer.question.content = 'Why are raccoons so good?'
+      answer.question.author_is_anonymous = true
+      answer.question.save!
+      answer.content = 'Because they are good cunes.'
+      answer.save!
+
+      service.post(answer)
+
+      expect(tumblr_client).to have_received(:text).with(
+        service.uid,
+        title: 'Anonymous asked: Why are raccoons so good?',
+        body: "Because they are good cunes.\n\n[Smile or comment on the answer here](https://example.com/#{user.screen_name}/a/#{answer.id})",
+        format: 'markdown',
+        tweet: 'off'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Oops, looks like I broke Tumblr sharing with #232 

Here's the fix and a test to check for it to work, and included with it come adjusted specs for `SocialHelper::` which should work on non-CI systems with custom hostnames as well!