### PR TITLE
Fix application crashing without Sentry being configured

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,3 @@
-return unless APP_CONFIG[:sentry_dsn]
-
 Sentry.init do |config|
   config.dsn = APP_CONFIG[:sentry_dsn]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]


### PR DESCRIPTION
Fixes #242 

If `Sentry.init` is not called, `Sentry` is still defined, but nothing inside it works properly, making checks outside hardly possible. Letting Sentry initialize without a DSN still works fine, as it just has nothing to report to.

Checked the logs and there are no exceptions etc.