### PR TITLE
Move turbolinks progressbar to the bottom on tablet and lower

### DIFF
--- a/app/assets/stylesheets/overrides/_turbolinks.scss
+++ b/app/assets/stylesheets/overrides/_turbolinks.scss
@@ -1,7 +1,7 @@
 .turbolinks-progress-bar {
   background: var(--turbolinks-progress-color);
 
-  @include media-breakpoint-down('sm') {
+  @include media-breakpoint-down('md') {
     top: unset !important;
     bottom: 0 !important;
     position: fixed;

--- a/app/assets/stylesheets/overrides/_turbolinks.scss
+++ b/app/assets/stylesheets/overrides/_turbolinks.scss
@@ -3,7 +3,7 @@
 
   @include media-breakpoint-down('md') {
     top: unset !important;
-    bottom: 45px !important;
+    bottom: calc(45px + env(safe-area-inset-bottom)) !important;
     position: fixed;
     left: 0 !important;
   }

--- a/app/assets/stylesheets/overrides/_turbolinks.scss
+++ b/app/assets/stylesheets/overrides/_turbolinks.scss
@@ -1,3 +1,10 @@
 .turbolinks-progress-bar {
   background: var(--turbolinks-progress-color);
+
+  @include media-breakpoint-down('sm') {
+    top: unset !important;
+    bottom: 0 !important;
+    position: fixed;
+    left: 0 !important;
+  }
 }

--- a/app/assets/stylesheets/overrides/_turbolinks.scss
+++ b/app/assets/stylesheets/overrides/_turbolinks.scss
@@ -3,7 +3,7 @@
 
   @include media-breakpoint-down('md') {
     top: unset !important;
-    bottom: 0 !important;
+    bottom: 45px !important;
     position: fixed;
     left: 0 !important;
   }


### PR DESCRIPTION
Fixes #215 

(the `!important` are required because Turbolinks injects it's own style tag and there's no easier way overriding it's styling)