### PR TITLE
Prevent exceptions with invalid URIs

### DIFF
--- a/app/services/shared_markers.rb
+++ b/app/services/shared_markers.rb
@@ -2,16 +2,14 @@ module SharedMarkers
   include ActionView::Helpers::TagHelper
 
   def autolink(link, _link_type)
-    begin
-      href = if ALLOWED_HOSTS_IN_MARKDOWN.include?(URI(link).host)
-              link
-            else
-              linkfilter_path(url: link)
-            end
-      
-      content_tag(:a, link, href: href, target: "_blank", rel: "nofollow")
-    rescue
-      link
-    end
+    href = if ALLOWED_HOSTS_IN_MARKDOWN.include?(URI(link).host)
+            link
+          else
+            linkfilter_path(url: link)
+          end
+    
+    content_tag(:a, link, href: href, target: "_blank", rel: "nofollow")
+  rescue
+    link
   end
 end

--- a/app/services/shared_markers.rb
+++ b/app/services/shared_markers.rb
@@ -3,11 +3,11 @@ module SharedMarkers
 
   def autolink(link, _link_type)
     href = if ALLOWED_HOSTS_IN_MARKDOWN.include?(URI(link).host)
-            link
-          else
-            linkfilter_path(url: link)
-          end
-    
+             link
+           else
+             linkfilter_path(url: link)
+           end
+
     content_tag(:a, link, href: href, target: "_blank", rel: "nofollow")
   rescue
     link

--- a/app/services/shared_markers.rb
+++ b/app/services/shared_markers.rb
@@ -2,12 +2,16 @@ module SharedMarkers
   include ActionView::Helpers::TagHelper
 
   def autolink(link, _link_type)
-    href = if ALLOWED_HOSTS_IN_MARKDOWN.include?(URI(link).host)
-             link
-           else
-             linkfilter_path(url: link)
-           end
-
-    content_tag(:a, link, href: href, target: "_blank", rel: "nofollow")
+    begin
+      href = if ALLOWED_HOSTS_IN_MARKDOWN.include?(URI(link).host)
+              link
+            else
+              linkfilter_path(url: link)
+            end
+      
+      content_tag(:a, link, href: href, target: "_blank", rel: "nofollow")
+    rescue
+      link
+    end
   end
 end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -62,6 +62,14 @@ describe MarkdownHelper, :type => :helper do
     it 'should not process any markup aside of links' do
       expect(question_markdown('**your account has been disabled**, [click here to enable it again](https://evil.example.com)')). to eq('<p>**your account has been disabled**, [click here to enable it again](<a href="/linkfilter?url=https%3A%2F%2Fevil.example.com" target="_blank" rel="nofollow">https://evil.example.com</a>)</p>')
     end
+
+    it 'should not raise an exception if an invalid link is processed' do
+      expect{ question_markdown('https://example.com/example.質問') }.not_to raise_error
+    end
+
+    it 'should not process invalid links' do
+      expect(question_markdown('https://example.com/example.質問')).to eq('<p>https://example.com/example.質問</p>')
+    end
   end
 
   describe '#raw_markdown' do


### PR DESCRIPTION
We saw increased frequency of issues with those on Sentry, this just prevents those "faulty" combinations to be linked at all.

Also includes test cases to check for that behaviour!