### PR TITLE
Mute Rules - Post-Release Fixes

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,7 +1,7 @@
 class UserController < ApplicationController
   include ThemeHelper
 
-  before_action :authenticate_user!, only: %w(edit update edit_privacy update_privacy edit_theme update_theme preview_theme delete_theme data export begin_export edit_security update_2fa destroy_2fa reset_user_recovery_codes)
+  before_action :authenticate_user!, only: %w(edit update edit_privacy update_privacy edit_theme update_theme preview_theme delete_theme data export begin_export edit_security update_2fa destroy_2fa reset_user_recovery_codes edit_mute)
 
   def show
     @user = User.where('LOWER(screen_name) = ?', params[:username].downcase).includes(:profile).first!

--- a/app/javascript/retrospring/features/settings/index.ts
+++ b/app/javascript/retrospring/features/settings/index.ts
@@ -2,7 +2,7 @@ import {createDeleteEvent, createSubmitEvent} from "retrospring/features/setting
 
 export default (): void => {
   const submit: HTMLButtonElement = document.getElementById('new-rule-submit') as HTMLButtonElement;
-  if (submit.classList.contains('js-initialized')) return;
+  if (!submit || submit.classList.contains('js-initialized')) return;
 
   const rulesList = document.querySelector<HTMLDivElement>('.js-rules-list');
   rulesList.querySelectorAll<HTMLDivElement>('.form-group:not(.js-initalized)').forEach(entry => {


### PR DESCRIPTION
I found some stuff that needed fixing, even stumbled upon one thing by accident.

1. Noticed the console was spammed with `submit is undefined` errors everywhere, because the query can only succeed on the Mute settings page, added a condition to the early return to prevent those.
2. `/settings/muted` is not auth guarded. The site will just error out if functionality is attempted to be used, but it shouldn't be accessible anyway.