### PR TITLE
Assign lockfiles to proper owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 
 # Ruby/Backend related code
 *.rb @nilsding
+Gemfile.lock @nilsding
 
 # Frontend assets
 *.coffee @pixeldesu
@@ -12,6 +13,7 @@
 *.json @pixeldesu
 *.scss @pixeldesu
 *.ts @pixeldesu
+yarn.lock @pixeldesu
 
 # Frontend views
 *.haml @pixeldesu


### PR DESCRIPTION
Because `yarn.lock` changes are definitely not something a backend dev needs to look at.