### PR TITLE
confirmation_instructions: add "do not reply" remark to the email body

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.haml
+++ b/app/views/devise/mailer/confirmation_instructions.haml
@@ -8,3 +8,5 @@
 %p{ style: 'margin:0px;padding:0px' } You can confirm your account email through the link below:
 %p{ style: 'margin:0px;padding:0px' }
   = link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token, protocol: (APP_CONFIG['https'] ? :https : :http))
+%p &nbsp;
+%p{ style: 'margin:0px;padding:0px' } Please do not reply to this email.

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -4,3 +4,5 @@ You can confirm your account email by copying link below,
 and entering it into your browser.
 
 <%= confirmation_url(@resource, confirmation_token: @token, protocol: (APP_CONFIG['https'] ? :https : :http)) %>
+
+Please do not reply to this email.


### PR DESCRIPTION
There have been several replies to this email containing nothing but the sentence `Yes, I confirm.` or just simply `Confirmed`.  It seems like someone discovered that replying to the email with exactly that helped with recovering their Twitter account after it was locked, and now people try to do this everywhere else.