### PR TITLE
Remove legacy stylesheet pack tag

### DIFF
--- a/app/views/layouts/base.haml
+++ b/app/views/layouts/base.haml
@@ -17,7 +17,6 @@
     = stylesheet_pack_tag 'application', data: { 'turbolinks-track': 'reload' }
     = javascript_pack_tag 'application', data: { 'turbolinks-track': 'reload' }
     = javascript_pack_tag 'legacy', data: { 'turbolinks-track': 'reload' }
-    = stylesheet_pack_tag 'legacy', data: { 'turbolinks-track': 'reload' }
     = csrf_meta_tags
     = yield(:og)
     = yield(:meta)


### PR DESCRIPTION
Because Rails response to a non-existing asset on production will be
![611797](https://user-images.githubusercontent.com/1774242/149223324-64b3da61-c1e6-4af7-90fd-5d7acc52875a.jpg)

