### PR TITLE
Set some stricter Rubocop rules

### DIFF
--- a/.github/workflows/retrospring.yml
+++ b/.github/workflows/retrospring.yml
@@ -74,8 +74,6 @@ jobs:
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
           REDIS_URL: "redis://localhost:${{ job.services.redis.ports[6379] }}"
-      - name: Lint HAML templates
-        run: bundle exec haml-lint app/views
       - name: Lint TypeScript
         run: yarn run lint
       - uses: codecov/codecov-action@v1

--- a/.houndci.yml
+++ b/.houndci.yml
@@ -1,0 +1,14 @@
+sass-lint:
+  enabled: false
+
+coffeescript:
+  enabled: false
+
+jshint:
+  enabled: false
+
+haml:
+  config_file: .haml-lint.yml
+
+rubocop:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rt_rubocop_defaults
   - rubocop-rails
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - 'config/**/*'
     - 'vendor/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
-require: 
-  - rt_rubocop_defaults
+require:
   - rubocop-rails
 AllCops:
-  TargetRubyVersion: 2.7
+  DisplayCopNames: true
+  CacheRootDirectory: '.git'
   Exclude:
     - 'config/**/*'
     - 'vendor/**/*'
@@ -10,12 +10,25 @@ AllCops:
     - 'db/seeds.rb'
     - 'bin/**/*'
     - 'node_modules/**/*'
+    - coverage/**/*
+  TargetRubyVersion: 2.7
+  NewCops: enable
 
 Rails:
   Enabled: true
 
 Rails/InverseOf:
   Enabled: false
+
+
+### Lint
+
+Lint/NestedMethodDefinition:
+  Exclude:
+    - api/sinatra/**/*
+
+
+### Metrics
 
 Metrics/AbcSize:
   Max: 20
@@ -30,10 +43,84 @@ Metrics/MethodLength:
   Exclude:
     - 'db/migrate/*.rb'
 
-Style/ClassAndModuleChildren:
+Metrics/BlockLength:
+  Exclude:
+    - '*.gemspec'
+    - '**/*.rake'
+    - 'api/**/*'
+    - 'app/api/routes.rb'
+    - 'config/initialize/**/*'
+    - 'config/initializers/**/*'
+    - 'spec/**/*'
+
+Metrics/ClassLength:
+  Exclude:
+    - spec/**/*
+
+Metrics/CyclomaticComplexity:
+  Severity: refactor
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'app/api/routes.rb'
+    - 'spec/requests/**/*'
+
+
+### Style / Layout
+
+#### Hash
+Layout/HashAlignment:
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+
+Style/HashTransformKeys:
   Enabled: false
 
+Style/HashTransformValues:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span more than one line.
+  EnforcedStyle: indented
+
+#### Rest
 Style/Documentation:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/ExponentialNotation:
+  # https://docs.rubocop.org/rubocop/cops_style.html#styleexponentialnotation
+  EnforcedStyle: engineering
+
+Style/NumericLiterals:
+  Description: Add underscores to large numeric literals to improve their readability.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/RaiseArgs:
+  EnforcedStyle: compact
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/RescueStandardError:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,23 +1,43 @@
+require: 
+  - rt_rubocop_defaults
+  - rubocop-rails
 AllCops:
-  NewCops: enable
+  TargetRubyVersion: 2.5
   Exclude:
+    - 'config/**/*'
     - 'vendor/**/*'
     - 'db/schema.rb'
+    - 'db/seeds.rb'
+    - 'bin/**/*'
+    - 'node_modules/**/*'
 
-Metrics/ClassLength:
+Rails:
+  Enabled: true
+
+Rails/InverseOf:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 20
+  Exclude:
+    - 'db/**/*'
 
 Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
+  Max: 15
+  Exclude:
+    - 'db/migrate/*.rb'
 
 Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/Documentation:
+  Enabled: false
+
+Style/RescueStandardError:
+  Enabled: false
+
+Style/Encoding:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -94,9 +94,9 @@ group :development, :test do
   gem 'timecop'
   gem 'rails-controller-testing'
   gem 'haml_lint', require: false
+  gem 'rt_rubocop_defaults', '~> 2.3', '>= 2.3.1'
   gem 'rubocop', '~> 1.22', '>= 1.22.1'
   gem 'rubocop-rails', '~> 2.13', '>= 2.13.1'
-  gem 'rt_rubocop_defaults', '~> 2.3', '>= 2.3.1'
 end
 
 gem "webpacker", "~> 5.2"

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,8 @@ group :development, :test do
   gem 'timecop'
   gem 'rails-controller-testing'
   gem 'haml_lint', require: false
+  gem 'rubocop-rails', '~> 2.13', '>= 2.13.1'
+  gem 'rt_rubocop_defaults', '~> 2.3', '>= 2.3.1'
 end
 
 gem "webpacker", "~> 5.2"

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ group :development, :test do
   gem 'timecop'
   gem 'rails-controller-testing'
   gem 'haml_lint', require: false
+  gem 'rubocop', '~> 1.22', '>= 1.22.1'
   gem 'rubocop-rails', '~> 2.13', '>= 2.13.1'
   gem 'rt_rubocop_defaults', '~> 2.3', '>= 2.3.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,102 +1,101 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 6.1'
-gem 'rails-i18n', '~> 6.0'
-gem 'i18n-js', '= 3.6'
+gem "i18n-js", "= 3.6"
+gem "rails", "~> 6.1"
+gem "rails-i18n", "~> 6.0"
 
-gem 'pg'
+gem "pg"
 
-gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
-gem 'turbolinks', '~> 2.5.3'
-gem 'jbuilder', '~> 2.10'
+gem "jbuilder", "~> 2.10"
+gem "sass-rails", "~> 5.0"
+gem "turbolinks", "~> 2.5.3"
+gem "uglifier", ">= 1.3.0"
 
-gem 'bcrypt', '~> 3.1.7'
+gem "bcrypt", "~> 3.1.7"
 
-gem 'haml', '~> 5.0'
-gem 'devise', '~> 4.0'
-gem 'devise-i18n'
-gem 'devise-async'
-gem 'active_model_otp'
-gem 'rqrcode'
-gem 'bootstrap_form'
-gem 'fog-core'
-gem 'fog-aws'
-gem 'fog-local'
-gem 'colorize'
-gem 'carrierwave', '~> 2.0'
-gem 'carrierwave_backgrounder', git: 'https://github.com/mltnhm/carrierwave_backgrounder.git'
-gem 'mini_magick'
+gem "active_model_otp"
+gem "bootstrap_form"
+gem "carrierwave", "~> 2.0"
+gem "carrierwave_backgrounder", git: "https://github.com/mltnhm/carrierwave_backgrounder.git"
+gem "colorize"
+gem "devise", "~> 4.0"
+gem "devise-async"
+gem "devise-i18n"
+gem "fog-aws"
+gem "fog-core"
+gem "fog-local"
+gem "haml", "~> 5.0"
 gem "hcaptcha", "~> 6.0", git: "https://github.com/Retrospring/hcaptcha.git", ref: "v6.0.2"
+gem "mini_magick"
+gem "rqrcode"
 
 gem "rolify", "~> 5.2"
 
 gem "dry-initializer", "~> 3.0"
 gem "dry-types", "~> 1.4"
 
-gem 'ruby-progressbar'
+gem "ruby-progressbar"
 
-gem 'rails_admin'
-gem 'pghero'
-gem "sentry-ruby"
+gem "pghero"
+gem "rails_admin"
 gem "sentry-rails"
+gem "sentry-ruby"
 gem "sentry-sidekiq"
 
-gem 'sidekiq', "< 6" # remove version constraint once we have redis 5
+gem "sidekiq", "< 6" # remove version constraint once we have redis 5
 
-gem 'questiongenerator', '~> 1.0'
+gem "questiongenerator", "~> 1.0"
 
-gem 'sanitize'
-gem 'redcarpet'
-gem 'httparty'
+gem "httparty"
+gem "redcarpet"
+gem "sanitize"
 
 # OmniAuth and providers
-gem 'omniauth'
-gem 'omniauth-twitter'
+gem "omniauth"
+gem "omniauth-twitter"
 
 # OAuth clients
-gem 'twitter'
-gem 'twitter-text'
+gem "twitter"
+gem "twitter-text"
 
-gem 'redis'
+gem "redis"
 
-gem 'fake_email_validator'
+gem "fake_email_validator"
 
 group :development do
-  gem 'spring', '~> 2.0'
-  gem 'byebug'
-  gem 'web-console', '~> 4.0'
-  gem 'binding_of_caller'
+  gem "binding_of_caller"
+  gem "byebug"
+  gem "spring", "~> 2.0"
+  gem "web-console", "~> 4.0"
 end
 
-gem 'puma'
+gem "puma"
 
 group :development, :test do
-  gem 'rake'
-  gem 'rspec-mocks'
-  gem 'rspec-rails', '~> 4.0'
-  gem 'rspec-its', '~> 1.3'
+  gem "better_errors"
+  gem "brakeman"
+  gem "capybara"
+  gem "database_cleaner"
+  gem "factory_bot_rails", require: false
+  gem "faker"
+  gem "guard-brakeman"
+  gem "haml_lint", require: false
+  gem "letter_opener" # Use this just in local test environments
+  gem "poltergeist"
+  gem "rails-controller-testing"
+  gem "rake"
+  gem "rspec-its", "~> 1.3"
+  gem "rspec-mocks"
+  gem "rspec-rails", "~> 4.0"
   gem "rspec-sidekiq", "~> 3.0", require: false
-  gem 'factory_bot_rails', require: false
-  gem 'faker'
-  gem 'capybara'
-  gem 'poltergeist'
-  gem 'simplecov', require: false
-  gem 'simplecov-json', require: false
-  gem 'simplecov-cobertura', require: false
-  gem 'database_cleaner'
-  gem 'better_errors'
-  gem 'letter_opener' # Use this just in local test environments
-  gem 'brakeman'
-  gem 'guard-brakeman'
-  gem 'timecop'
-  gem 'rails-controller-testing'
-  gem 'haml_lint', require: false
-  gem 'rt_rubocop_defaults', '~> 2.3', '>= 2.3.1'
-  gem 'rubocop', '~> 1.22', '>= 1.22.1'
-  gem 'rubocop-rails', '~> 2.13', '>= 2.13.1'
+  gem "rubocop", "~> 1.22", ">= 1.22.1"
+  gem "rubocop-rails", "~> 2.13", ">= 2.13.1"
+  gem "simplecov", require: false
+  gem "simplecov-cobertura", require: false
+  gem "simplecov-json", require: false
+  gem "timecop"
 end
 
 gem "webpacker", "~> 5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -665,6 +665,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0)
   rspec-sidekiq (~> 3.0)
   rt_rubocop_defaults (~> 2.3, >= 2.3.1)
+  rubocop (~> 1.22, >= 1.22.1)
   rubocop-rails (~> 2.13, >= 2.13.1)
   ruby-progressbar
   sanitize

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,8 +474,6 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.10.3)
-    rt_rubocop_defaults (2.3.1)
-      rubocop (~> 1.5)
     rubocop (1.24.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -664,7 +662,6 @@ DEPENDENCIES
   rspec-mocks
   rspec-rails (~> 4.0)
   rspec-sidekiq (~> 3.0)
-  rt_rubocop_defaults (~> 2.3, >= 2.3.1)
   rubocop (~> 1.22, >= 1.22.1)
   rubocop-rails (~> 2.13, >= 2.13.1)
   ruby-progressbar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,6 +474,8 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.10.3)
+    rt_rubocop_defaults (2.3.1)
+      rubocop (~> 1.5)
     rubocop (1.24.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -485,6 +487,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
+    rubocop-rails (2.13.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
@@ -658,6 +664,8 @@ DEPENDENCIES
   rspec-mocks
   rspec-rails (~> 4.0)
   rspec-sidekiq (~> 3.0)
+  rt_rubocop_defaults (~> 2.3, >= 2.3.1)
+  rubocop-rails (~> 2.13, >= 2.13.1)
   ruby-progressbar
   sanitize
   sass-rails (~> 5.0)


### PR DESCRIPTION
We don't really check our code with Rubocop at the moment, and we should change that.

This configuration is based on a project we wrote in Rails before and includes a sane (but strict) set of rules to follow.

After we merge this, we should do one of the following:
* Enable some kind of SaaS GitHub PR integration (like HoundCI or Codacy) that checks new code for style violations
  * ...with the negative that they most likely don't support arbitrary imports (like `rt_rubocop_defaults`)
* Add a GitHub Actions step that runs `bundle exec rubocop`
  * ...which we need to set to `continue-on-error` until we fixed all violations
* Setup https://github.com/reviewdog/action-rubocop to run on PRs
  * ...which requires a new GitHub user of which we use the token to pass to the action to gives us comments on PRs