### PR TITLE
Fix logout showing a 404 page

### DIFF
--- a/app/views/navigation/main/_profile.haml
+++ b/app/views/navigation/main/_profile.haml
@@ -32,6 +32,6 @@
         %i.fa.fa-fw.fa-gavel
         = t('views.navigation.moderation')
       .dropdown-divider
-    %a.dropdown-item{ href: destroy_user_session_path, data: { method: :delete } }
+    = button_to destroy_user_session_path, method: 'delete', class: 'dropdown-item' do
       %i.fa.fa-fw.fa-sign-out
       = t 'views.sessions.destroy'

--- a/app/views/navigation/mobile/_profile.haml
+++ b/app/views/navigation/mobile/_profile.haml
@@ -26,6 +26,6 @@
       %i.fa.fa-fw.fa-gavel
       = t('views.navigation.moderation')
     .dropdown-divider
-  %a.dropdown-item{ href: destroy_user_session_path, data: { method: :delete } }
+  = button_to destroy_user_session_path, method: 'delete', class: 'dropdown-item' do
     %i.fa.fa-fw.fa-sign-out
     = t 'views.sessions.destroy'


### PR DESCRIPTION
Report from here:
https://twitter.com/Psilocervine/status/1482208816691388416

Verified it myself rather quickly, and I might know where this comes from:

Rails UJS provides the helpers for handling this using `data-method`, at least it did so during the jQuery days. Good thing I already stumbled upon the replacement for this a few days ago (`button_to`) and was able to fix the issue rather quickly.