### PR TITLE
Add bullet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ gem "puma"
 group :development, :test do
   gem "better_errors"
   gem "brakeman"
+  gem "bullet"
   gem "capybara"
   gem "database_cleaner"
   gem "factory_bot_rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     brakeman (5.2.0)
     buftok (0.2.0)
     builder (3.2.4)
+    bullet (7.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.36.0)
       addressable
@@ -587,6 +590,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    uniform_notifier (1.14.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -616,6 +620,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap_form
   brakeman
+  bullet
   byebug
   capybara
   carrierwave (~> 2.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,12 @@
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.sentry        = true
+    Bullet.rails_logger  = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on


### PR DESCRIPTION
https://github.com/flyerhzm/bullet

> The Bullet gem is designed to help you increase your application's performance by reducing the number of queries it makes. It will watch your queries while you develop your application and notify you when you should add eager loading (N+1 queries), when you're using eager loading that isn't necessary and when you should use counter cache.

Configured it to cry into Sentry too, you can already see that in **RETROSPRING-38**