### PR TITLE
Add lograge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,10 @@ group :development, :test do
   gem "timecop"
 end
 
+group :production do
+  gem "lograge"
+end
+
 gem "webpacker", "~> 5.2"
 
 gem "omniauth-rails_csrf_protection", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,11 @@ GEM
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -445,6 +450,8 @@ GEM
     redis (4.1.4)
     regexp_parser (2.2.0)
     remotipart (1.4.4)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -647,6 +654,7 @@ DEPENDENCIES
   jbuilder (~> 2.10)
   jwt (~> 2.3)
   letter_opener
+  lograge
   mini_magick
   omniauth
   omniauth-rails_csrf_protection (~> 1.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,6 +49,9 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
+  # Better log formatting
+  config.lograge.enabled = true
+
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 


### PR DESCRIPTION
https://github.com/roidrage/lograge

> Lograge is an attempt to bring sanity to Rails' noisy and unusable, unparsable and, in the context of running multiple processes and servers, unreadable default logging output. Rails' default approach to log everything is great during development, it's terrible when running it in production. It pretty much renders Rails logs useless to me.

Only installed in `production` group and used in the same environment