### PR TITLE
Add translations for account settings (+ user register/login)

### DIFF
--- a/app/views/devise/registrations/edit.haml
+++ b/app/views/devise/registrations/edit.haml
@@ -1,4 +1,4 @@
-= render 'settings/account'
+= render "settings/account"
 
-- provide(:title, generate_title('Account Settings'))
-- parent_layout 'user/settings'
+- provide(:title, generate_title(t(".title")))
+- parent_layout "user/settings"

--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -1,26 +1,24 @@
-- provide(:title, generate_title('Sign Up'))
+- provide(:title, generate_title(t(".title")))
 .container
   .row
     .col-sm-8.offset-sm-2
       .card.mt-3
         .card-body
-          %h1= t('views.sessions.new')
+          %h1= t(".title")
           = bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-            = render 'devise/shared/error_messages', resource: resource
-            = render 'layouts/messages'
+            = render "devise/shared/error_messages", resource: resource
+            = render "layouts/messages"
 
-            = f.text_field :screen_name, autofocus: true, label: t('views.settings.account.username')
-            = f.email_field :email, autofocus: false, label: t('views.settings.account.email'),
-              help: "Don't forget to check your spam folder in case our mail might have landed there!"
-
-            = f.password_field :password, autocomplete: :off, label: t('views.settings.account.password')
-            = f.password_field :password_confirmation, autocomplete: :off, label: t('views.settings.account.password_confirm')
+            = f.text_field :screen_name, autofocus: true
+            = f.email_field :email, autofocus: false
+            = f.password_field :password, autocomplete: :off
+            = f.password_field :password_confirmation, autocomplete: :off
 
             - if APP_CONFIG.dig(:hcaptcha, :enabled)
               = hcaptcha_tags
 
-            %p= raw t('views.sessions.info', terms: link_to(t('views.general.terms'), terms_path))
-            = f.submit 'Sign up', class: 'btn btn-primary mb-3'
+            %p= raw t(".info", terms: link_to(t("voc.terms"), terms_path))
+            = f.primary
 
-          = render 'devise/shared/links'
-= render 'shared/links'
+          = render "devise/shared/links"
+= render "shared/links"

--- a/app/views/devise/sessions/new.haml
+++ b/app/views/devise/sessions/new.haml
@@ -1,20 +1,20 @@
-- provide(:title, generate_title('Sign In'))
+- provide(:title, generate_title(t(".title")))
 .container
   .row
     .col-sm-4.offset-sm-4
-      = render 'layouts/messages'
+      = render "layouts/messages"
       .card.mt-3
         .card-body
-          %h1.mb-3.mt-0= t('views.sessions.create')
+          %h1.mb-3.mt-0= t(".title")
           = bootstrap_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
 
-            = f.text_field :login, autofocus: true, label: t('views.settings.account.username')
-            = f.password_field :password, autocomplete: :off, label: t('views.settings.account.password')
+            = f.text_field :login, autofocus: true
+            = f.password_field :password, autocomplete: :off
 
             - if devise_mapping.rememberable?
               = f.check_box :remember_me
 
-            = f.submit t('views.sessions.create'), class: 'btn btn-primary mt-3 mb-3'
+            = f.primary t("voc.login")
 
-          = render 'devise/shared/links'
-= render 'shared/links'
+          = render "devise/shared/links"
+= render "shared/links"

--- a/app/views/modal/_password.haml
+++ b/app/views/modal/_password.haml
@@ -2,15 +2,12 @@
   .modal-dialog
     .modal-content
       .modal-header
-        %h5.modal-title#modal-passwd-label= t 'views.settings.account.modal.title'
+        %h5.modal-title#modal-passwd-label= t(".title")
         %button.close{ data: { dismiss: :modal }, type: :button }
           %span{ aria: { hidden: true } } ×
-          %span.sr-only= t 'views.actions.close'
+          %span.sr-only= t("voc.close")
       .modal-body
-        = f.password_field :current_password,
-          autocomplete: :off,
-          label: t('views.settings.account.password_current'),
-          help: t('views.settings.account.password_current_help')
+        = f.password_field :current_password, autocomplete: :off
       .modal-footer
-        %button.btn.btn-default{ data: { dismiss: :modal }, type: :button }= t 'views.actions.cancel'
-        %button.btn.btn-primary{ type: :submit }= t 'views.actions.save'
+        %button.btn.btn-default{ data: { dismiss: :modal }, type: :button }= t("voc.cancel")
+        = f.primary

--- a/app/views/modal/_password.haml
+++ b/app/views/modal/_password.haml
@@ -1,4 +1,4 @@
-.modal.fade#modal-passwd{ aria: { hidden: true, labelledby: 'modal-passwd-label' }, role: :dialog, tabindex: -1 }
+.modal.fade#modal-passwd{ aria: { hidden: true, labelledby: "modal-passwd-label" }, role: :dialog, tabindex: -1 }
   .modal-dialog
     .modal-content
       .modal-header

--- a/app/views/settings/_account.haml
+++ b/app/views/settings/_account.haml
@@ -1,29 +1,26 @@
 .card
   .card-body
-    = bootstrap_form_for(resource, as: resource_name, url: '/settings/account', html: { method: :put }) do |f|
-      = render 'modal/password', f: f
+    = bootstrap_form_for(resource, as: resource_name, url: "/settings/account", html: { method: :put }) do |f|
+      = render "modal/password", f: f
+      = render "devise/shared/error_messages", resource: resource
 
-      = render 'devise/shared/error_messages', resource: resource
+      = f.text_field :screen_name, autofocus: true
 
-      = f.text_field :screen_name, autofocus: true, label: t('views.settings.account.username')
-
-      = f.email_field :email, label: t('views.settings.account.email')
+      = f.email_field :email
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-        %div= raw t('views.settings.account.email_confirm', resource: resource.unconfirmed_email)
+        .alert.alert-info= raw t(".email_confirm", resource: resource.unconfirmed_email)
 
-      = f.password_field :password, autocomplete: :off, label: t('views.settings.account.password'), help: t('views.settings.account.password_help')
-      = f.password_field :password_confirmation, autocomplete: :off, label: t('views.settings.account.password_confirm')
+      = f.password_field :password, autocomplete: :off, help: t(".help.password")
+      = f.password_field :password_confirmation, autocomplete: :off
 
-      %button.btn.btn-primary{ data: { target: '#modal-passwd', toggle: :modal, type: :button } }
-        = t 'views.actions.save'
+      %button.btn.btn-primary{ data: { target: "#modal-passwd", toggle: :modal, type: :button } }
+        = t("voc.save")
 
       %hr/
     %p
-      = t 'views.settings.account.unsatisfied'
-      = button_to t('views.settings.account.delete'), '/settings/account', data: { confirm: 'Are you sure?' }, method: :delete, class: 'btn btn-danger btn-xs'
+      = t(".delete.heading")
+      = button_to t(".delete.action"), "/settings/account", data: { confirm: t(".delete.confirm") }, method: :delete, class: "btn btn-danger btn-xs"
 
-    = link_to t('views.settings.account.back'), :back
-
-.visible-xs= render 'shared/links'
+.visible-xs= render "shared/links"
 
 

--- a/app/views/settings/_account.haml
+++ b/app/views/settings/_account.haml
@@ -22,5 +22,3 @@
       = button_to t(".delete.action"), "/settings/account", data: { confirm: t(".delete.confirm") }, method: :delete, class: "btn btn-danger btn-xs"
 
 .visible-xs= render "shared/links"
-
-

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -20,10 +20,19 @@ en:
       service:
         post_tag: "Tag"
       user:
+        current_password: "Current password"
+        email: "Email"
+        login: "Username or Email"
+        password: "Password"
+        password_confirmation: "Confirm your password"
         profile_picture: "Profile picture"
         profile_header: "Profile header"
+        screen_name: "Username"
         show_foreign_themes: "Render other user themes when visiting their profile"
     help:
+      user:
+        email: "Don't forget to check your spam folder in case our mail might have landed there!"
+        current_password: "We need your current password to confirm your changes"
       profile:
         motivation_header: "Shown in the header of the question box on your profile. Motivate users to ask you questions!"
       services/twitter:
@@ -31,6 +40,8 @@ en:
   helpers:
     submit:
       user:
+        new: "Sign in"
+        create: :voc.register
         update: :voc.save
       profile:
         update: :voc.save

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,20 +368,6 @@ en:
         privacy: "Privacy"
         sharing: "Sharing"
         security: "Security"
-      account:
-        modal:
-          title: "Save account changes"
-        username: "User name"
-        email: "Email address"
-        email_confirm: "Currently awaiting confirmation for %{resource}"
-        password: "Password"
-        password_confirm: "Confirm password"
-        password_help: "Leave this blank if you don't want to change it"
-        password_current: "Current password"
-        password_current_help: "We need your current password to confirm your changes"
-        delete: "Delete my account"
-        unsatisfied: "Unsatisfied?"
-        back: "Back"
       privacy:
         anonymous: "Allow anonymous questions"
         public: "Show your answers in the public timeline"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,7 +444,28 @@ en:
     destroy:
       success: "Announcement has been deleted successfully."
       error: "Unable to delete announcement."
+  devise:
+    registrations:
+      edit:
+        title: "Account Settings"
+      new:
+        title: "Sign up"
+        info: "With signing up you accept our %{terms}"
+    sessions:
+      new:
+        title: "Sign in"
+  modal:
+    password:
+      title: "Save account changes"
   settings:
+    account:
+      email_confirm: "Currently awaiting confirmation for %{resource}"
+      help:
+        password: "Leave this blank if you don't want to change it"
+      delete:
+        action: "Delete my account"
+        confirm: "Are you sure?"
+        heading: "Unsatisfied?"
     profile:
       adjust:
         profile_picture: "Adjust your new profile picture"
@@ -484,9 +505,14 @@ en:
       success: :user.update.success
       error: :user.update.error
   voc:
+    cancel: "Cancel"
+    close: "Close"
     delete: "Delete"
     edit: "Edit"
+    login: "Sign in"
     save: "Save changes"
+    register: "Sign up"
+    terms: "Terms of Service"
     update: "Update"
   errors:
     base: "An error occurred"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,7 +259,6 @@ en:
       destroy: "Logout"
       create: "Sign in"
       new: "Sign up"
-      info: "With signing up you accept our %{terms}"
     moderation:
       tabs:
         all: "All reports"


### PR DESCRIPTION
As the account settings touch attributes for the `User` model, I decided to also include the "Sign in/up" pages here.

**Testing:**
* Register an account and check the locales
* Login and check the locales on the sign in page
* Go to `/settings/account` and check the labels and locales present