### PR TITLE
Split locale scopes into separate files

### DIFF
--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -1,0 +1,33 @@
+en:
+  announcement:
+    create:
+      success: "Announcement created successfully."
+      error: "Unable to create announcement."
+    update:
+      success: "Announcement updated successfully."
+      error: "Unable to save announcement."
+    destroy:
+      success: "Announcement has been deleted successfully."
+      error: "Unable to delete announcement."
+  services:
+    create:
+      success: "Service connected successfully."
+      duplicate: "The %{service} account you are trying to connect is already connected to another %{app} account. If you are unable to disconnect the account yourself, please send us a Direct Message on Twitter: @retrospring."
+      error: "Unable to connect service."
+    update:
+      success: "Service updated successfully."
+      error: "Unable to update service."
+    failure:
+      error: :errors.base
+    destroy:
+      success: "Service removed successfully."
+  user:
+    update:
+      success: "Profile updated successfully."
+      error: "Unable to update profile."
+      notice:
+        profile_picture: " It might take a few minutes until your new profile picture is shown everywhere."
+        profile_header: " It might take a few minutes until your new profile header is shown everywhere."
+    update_profile:
+      success: :user.update.success
+      error: :user.update.error

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,38 +411,6 @@ en:
           invalid_code: "The code you entered was invalid."
         setup:
           success: "Two factor authentication has been enabled for your account."
-  announcement:
-    create:
-      success: "Announcement created successfully."
-      error: "Unable to create announcement."
-    update:
-      success: "Announcement updated successfully."
-      error: "Unable to save announcement."
-    destroy:
-      success: "Announcement has been deleted successfully."
-      error: "Unable to delete announcement."
-  services:
-    create:
-      success: "Service connected successfully."
-      duplicate: "The %{service} account you are trying to connect is already connected to another %{app} account. If you are unable to disconnect the account yourself, please send us a Direct Message on Twitter: @retrospring."
-      error: "Unable to connect service."
-    update:
-      success: "Service updated successfully."
-      error: "Unable to update service."
-    failure:
-      error: :errors.base
-    destroy:
-      success: "Service removed successfully."
-  user:
-    update:
-      success: "Profile updated successfully."
-      error: "Unable to update profile."
-      notice:
-        profile_picture: " It might take a few minutes until your new profile picture is shown everywhere."
-        profile_header: " It might take a few minutes until your new profile header is shown everywhere."
-    update_profile:
-      success: :user.update.success
-      error: :user.update.error
   voc:
     cancel: "Cancel"
     close: "Close"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,24 +411,3 @@ en:
           invalid_code: "The code you entered was invalid."
         setup:
           success: "Two factor authentication has been enabled for your account."
-  errors:
-    base: "An error occurred"
-
-    bad_request: "Bad Request"
-    param_is_missing: "param is missing"
-
-    forbidden: "This is illegal, you know"
-    blocked: "You have been blocked from performing this request"
-    other_blocked_self: "You have been blocked by this user"
-    asking_other_blocked_self: "You have been blocked from asking this user questions"
-    following_other_blocked_self: "You have been blocked from following this user"
-    self_blocked_other: "You cannot do this while blocking this user"
-    asking_self_blocked_other: "You cannot ask an user who you are currently blocking"
-    following_self_blocked_other: "You cannot follow an user who you are currently blocking"
-    self_action: "You cannot do this to yourself"
-    following_self: "You cannot follow yourself"
-
-    not_found: "That does not exist"
-    user_not_found: "User not found"
-
-    conflict: "This already exists"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,60 +412,16 @@ en:
         setup:
           success: "Two factor authentication has been enabled for your account."
   announcement:
-    index:
-      title: :activerecord.models.announcement.other
-      confirm: "Are you sure you want to delete this announcement?"
-      new: "Add Announcement"
-    new:
-      title: "Create Announcement"
     create:
       success: "Announcement created successfully."
       error: "Unable to create announcement."
-    edit:
-      title: "Edit Announcement"
     update:
       success: "Announcement updated successfully."
       error: "Unable to save announcement."
     destroy:
       success: "Announcement has been deleted successfully."
       error: "Unable to delete announcement."
-  devise:
-    registrations:
-      edit:
-        title: "Account Settings"
-      new:
-        title: "Sign up"
-        info: "With signing up you accept our %{terms}"
-    sessions:
-      new:
-        title: "Sign in"
-  modal:
-    password:
-      title: "Save account changes"
-  settings:
-    account:
-      email_confirm: "Currently awaiting confirmation for %{resource}"
-      help:
-        password: "Leave this blank if you don't want to change it"
-      delete:
-        action: "Delete my account"
-        confirm: "Are you sure?"
-        heading: "Unsatisfied?"
-    profile:
-      adjust:
-        profile_picture: "Adjust your new profile picture"
-        profile_header: "Adjust your new profile header"
-    services:
-      services:
-        one: "Sharing is enabled for the following service:"
-        other: "Sharing is enabled for the following services:"
-        zero: "You have not connected any services yet."
-      connect: "Connect to %{service}"
-      disconnect: "Disconnect"
-      confirm: "Really disconnect service %{service}?"
   services:
-    index:
-      title: "Service Settings"
     create:
       success: "Service connected successfully."
       duplicate: "The %{service} account you are trying to connect is already connected to another %{app} account. If you are unable to disconnect the account yourself, please send us a Direct Message on Twitter: @retrospring."
@@ -478,8 +434,6 @@ en:
     destroy:
       success: "Service removed successfully."
   user:
-    edit:
-      title: "Profile Settings"
     update:
       success: "Profile updated successfully."
       error: "Unable to update profile."
@@ -520,10 +474,3 @@ en:
     user_not_found: "User not found"
 
     conflict: "This already exists"
-  feedback:
-    consent:
-      title: "Feedback"
-    bugs:
-      title: "Bugs – Feedback"
-    features:
-      title: "Feature Requests – Feedback"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,16 +411,6 @@ en:
           invalid_code: "The code you entered was invalid."
         setup:
           success: "Two factor authentication has been enabled for your account."
-  voc:
-    cancel: "Cancel"
-    close: "Close"
-    delete: "Delete"
-    edit: "Edit"
-    login: "Sign in"
-    save: "Save changes"
-    register: "Sign up"
-    terms: "Terms of Service"
-    update: "Update"
   errors:
     base: "An error occurred"
 

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -1,0 +1,22 @@
+en:
+  errors:
+    base: "An error occurred"
+
+    bad_request: "Bad Request"
+    param_is_missing: "param is missing"
+
+    forbidden: "This is illegal, you know"
+    blocked: "You have been blocked from performing this request"
+    other_blocked_self: "You have been blocked by this user"
+    asking_other_blocked_self: "You have been blocked from asking this user questions"
+    following_other_blocked_self: "You have been blocked from following this user"
+    self_blocked_other: "You cannot do this while blocking this user"
+    asking_self_blocked_other: "You cannot ask an user who you are currently blocking"
+    following_self_blocked_other: "You cannot follow an user who you are currently blocking"
+    self_action: "You cannot do this to yourself"
+    following_self: "You cannot follow yourself"
+
+    not_found: "That does not exist"
+    user_not_found: "User not found"
+
+    conflict: "This already exists"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -1,0 +1,57 @@
+en:
+  announcement:
+    index:
+      title: :activerecord.models.announcement.other
+      confirm: "Are you sure you want to delete this announcement?"
+      new: "Add Announcement"
+    new:
+      title: "Create Announcement"
+    edit:
+      title: "Edit Announcement"
+  devise:
+    registrations:
+      edit:
+        title: "Account Settings"
+      new:
+        title: "Sign up"
+        info: "With signing up you accept our %{terms}"
+    sessions:
+      new:
+        title: "Sign in"
+  feedback:
+    consent:
+      title: "Feedback"
+    bugs:
+      title: "Bugs – Feedback"
+    features:
+      title: "Feature Requests – Feedback"
+  modal:
+    password:
+      title: "Save account changes"
+  services:
+    index:
+      title: "Service Settings"
+  settings:
+    account:
+      email_confirm: "Currently awaiting confirmation for %{resource}"
+      help:
+        password: "Leave this blank if you don't want to change it"
+      delete:
+        action: "Delete my account"
+        confirm: "Are you sure?"
+        heading: "Unsatisfied?"
+    profile:
+      adjust:
+        profile_picture: "Adjust your new profile picture"
+        profile_header: "Adjust your new profile header"
+    services:
+      services:
+        one: "Sharing is enabled for the following service:"
+        other: "Sharing is enabled for the following services:"
+        zero: "You have not connected any services yet."
+      connect: "Connect to %{service}"
+      disconnect: "Disconnect"
+      confirm: "Really disconnect service %{service}?"
+  user:
+    edit:
+      title: "Profile Settings"

--- a/config/locales/voc.en.yml
+++ b/config/locales/voc.en.yml
@@ -1,0 +1,11 @@
+en:
+  voc:
+    cancel: "Cancel"
+    close: "Close"
+    delete: "Delete"
+    edit: "Edit"
+    login: "Sign in"
+    save: "Save changes"
+    register: "Sign up"
+    terms: "Terms of Service"
+    update: "Update"


### PR DESCRIPTION
This is there to make the structure a bit more obvious, and also makes `en.yml` a kind of "legacy" file.

No locale actually changed in here, this is purely structural!