### PR TITLE
Add translations for user export

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -170,16 +170,16 @@ class UserController < ApplicationController
 
   def export
     if current_user.export_processing
-      flash[:info] = 'An export is currently in progress for this account.'
+      flash[:info] = t(".info")
     end
   end
 
   def begin_export
     if current_user.can_export?
       ExportWorker.perform_async(current_user.id)
-      flash[:success] = 'Your account is currently being exported.  This will take a little while.'
+      flash[:success] = t(".success")
     else
-      flash[:error] = 'Nice try, kid.'
+      flash[:error] = t(".error")
     end
 
     redirect_to user_export_path

--- a/app/views/settings/_export.haml
+++ b/app/views/settings/_export.haml
@@ -1,29 +1,20 @@
 .card
   .card-body
-    %h2 Export your data
-    %p
-      The data is inside a
-      %code= '.tar.gz'
-      archive and available in three formats: YAML, JSON, and XML.  The archive also contains a copy of your
-      profile picture and header picture in all sizes.
-    %p
-      Please note that you can only export your data once a week.  Exporting your data
-      will take a while, so please be patient.  You will receive a question once exporting
-      is done.
+    %h2= t(".heading")
+    = t(".body_html")
+
     - if current_user.can_export?
       %form{ action: begin_user_export_path, method: :post }
         %p.text-center
-          %button.btn.btn-lg.btn-primary#export-btn{ type: :submit } Export
+          %button.btn.btn-lg.btn-primary#export-btn{ type: :submit }= t(".export")
         = hidden_field_tag :authenticity_token, form_authenticity_token
     - else
       %p.text-center
-        %button.btn.btn-lg.btn-primary.disabled{ disabled: :disabled } Export
+        %button.btn.btn-lg.btn-primary.disabled{ disabled: :disabled }= t(".export")
     %p
       - if current_user.export_url.nil?
-        Once exporting your account is done, a download link will appear here.
+        = t(".export_url.none")
       - else
-        Here is your export from
-        = succeed ':' do
-          = current_user.export_created_at
+        = t(".export_url.present", time: current_user.export_created_at)
         %a{ href: current_user.export_url }
           = File.basename current_user.export_url

--- a/app/views/user/export.haml
+++ b/app/views/user/export.haml
@@ -1,4 +1,4 @@
-= render 'settings/export'
+= render "settings/export"
 
-- provide(:title, generate_title('Export'))
-- parent_layout 'user/settings'
+- provide(:title, generate_title(t(".title")))
+- parent_layout "user/settings"

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -22,6 +22,11 @@ en:
     destroy:
       success: "Service removed successfully."
   user:
+    export:
+      info: "An export is currently in progress for this account."
+    begin_export:
+      success: "Your account is currently being exported. This will take a little while."
+      error: "Exporting is currently not possible."
     update:
       success: "Profile updated successfully."
       error: "Unable to update profile."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -40,6 +40,18 @@ en:
         action: "Delete my account"
         confirm: "Are you sure?"
         heading: "Unsatisfied?"
+    export:
+      heading: "Export your data"
+      body_html: |
+        <p>The data is inside a <code>.tar.gz</code> archive and available in three formats: YAML, JSON, and XML. 
+        The archive also contains a copy of your profile picture and header picture in all sizes.</p>
+        <p>Please note that you can only export your data once a week. Exporting your data
+        will take a while, so please be patient. You will receive a question once exporting
+        is done.</p>
+      export: "Export"
+      export_url:
+        none: "Once exporting your account is done, a download link will appear here."
+        present: "Here's your export from %{time}"
     profile:
       adjust:
         profile_picture: "Adjust your new profile picture"
@@ -55,3 +67,5 @@ en:
   user:
     edit:
       title: "Profile Settings"
+    export:
+      title: "Export"


### PR DESCRIPTION
More untranslated things!

**Testing:**
* Visit `/settings/export` and verify that the translations look fine and that the general functionality still works