### PR TITLE
Add translations for 2FA controllers and actions

### DIFF
--- a/app/controllers/user/sessions_controller.rb
+++ b/app/controllers/user/sessions_controller.rb
@@ -16,7 +16,7 @@ class User::SessionsController < Devise::SessionsController
         session[:user_sign_in_uid] = resource.id
         sign_out(resource)
         warden.lock!
-        render 'auth/two_factor_authentication'
+        render "auth/two_factor_authentication"
       else
         if params[:user][:otp_attempt].length == 8
           found = TotpRecoveryCode.where(user_id: resource.id, code: params[:user][:otp_attempt].downcase).delete_all
@@ -24,14 +24,14 @@ class User::SessionsController < Devise::SessionsController
             flash[:info] = "You have #{TotpRecoveryCode.where(user_id: resource.id).count} recovery codes remaining."
             continue_sign_in(resource, resource_name)
           else
-            flash[:error] = t('views.auth.2fa.errors.invalid_code')
+            flash[:error] = t(".error")
             redirect_to new_user_session_url
           end
         elsif resource.authenticate_otp(params[:user][:otp_attempt], drift: APP_CONFIG.fetch(:otp_drift_period, 30).to_i)
           continue_sign_in(resource, resource_name)
         else
           sign_out(resource)
-          flash[:error] = t('views.auth.2fa.errors.invalid_code')
+          flash[:error] = t(".error")
           redirect_to new_user_session_url
         end
       end

--- a/app/controllers/user/sessions_controller.rb
+++ b/app/controllers/user/sessions_controller.rb
@@ -21,7 +21,7 @@ class User::SessionsController < Devise::SessionsController
         if params[:user][:otp_attempt].length == 8
           found = TotpRecoveryCode.where(user_id: resource.id, code: params[:user][:otp_attempt].downcase).delete_all
           if found == 1
-            flash[:info] = "You have #{TotpRecoveryCode.where(user_id: resource.id).count} recovery codes remaining."
+            flash[:info] = t(".info", count: TotpRecoveryCode.where(user_id: resource.id).count)
             continue_sign_in(resource, resource_name)
           else
             flash[:error] = t(".error")

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -192,7 +192,7 @@ class UserController < ApplicationController
 
       qr_code = RQRCode::QRCode.new(current_user.provisioning_uri("Retrospring:#{current_user.screen_name}", issuer: "Retrospring"))
 
-      @qr_svg = qr_code.as_svg({offset: 4, module_size: 4, color: "000;fill:var(--primary)"}).html_safe
+      @qr_svg = qr_code.as_svg({ offset: 4, module_size: 4, color: "000;fill:var(--primary)" }).html_safe
     else
       @recovery_code_count = current_user.totp_recovery_codes.count
     end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -192,7 +192,7 @@ class UserController < ApplicationController
 
       qr_code = RQRCode::QRCode.new(current_user.provisioning_uri("Retrospring:#{current_user.screen_name}", issuer: "Retrospring"))
 
-      @qr_svg = qr_code.as_svg({offset: 4, module_size: 4, color: '000;fill:var(--primary)'}).html_safe
+      @qr_svg = qr_code.as_svg({offset: 4, module_size: 4, color: "000;fill:var(--primary)"}).html_safe
     else
       @recovery_code_count = current_user.totp_recovery_codes.count
     end
@@ -206,9 +206,9 @@ class UserController < ApplicationController
       @recovery_keys = TotpRecoveryCode.generate_for(current_user)
       current_user.save!
 
-      render 'settings/security/recovery_keys'
+      render "settings/security/recovery_keys"
     else
-      flash[:error] = t('views.auth.2fa.errors.invalid_code')
+      flash[:error] = t(".error")
       redirect_to edit_user_security_path
     end
   end
@@ -217,7 +217,7 @@ class UserController < ApplicationController
     current_user.otp_module = :disabled
     current_user.save!
     current_user.totp_recovery_codes.delete_all
-    flash[:success] = 'Two factor authentication has been disabled for your account.'
+    flash[:success] = t(".success")
     redirect_to edit_user_security_path
   end
 

--- a/app/views/auth/two_factor_authentication.haml
+++ b/app/views/auth/two_factor_authentication.haml
@@ -1,14 +1,12 @@
 .container
   .row
     .col-sm-4.offset-sm-4
-      = render 'layouts/messages'
+      = render "layouts/messages"
       .card.mt-3
         .card-body
-          %h1.mb-3.mt-0= t('views.auth.2fa.title')
+          %h1.mb-3.mt-0= t(".heading")
           = bootstrap_form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f|
+            = f.text_field :otp_attempt, autofocus: true, label: t(".otp_attempt")
+            = f.submit t("voc.login"), class: "btn btn-primary mt-3 mb-3"
 
-            = f.text_field :otp_attempt, autofocus: true, label: 'Please enter the code from your authenticator app'
-
-            = f.submit t('views.sessions.create'), class: 'btn btn-primary mt-3 mb-3'
-
-= render 'shared/links'
+= render "shared/links"

--- a/app/views/settings/_security.haml
+++ b/app/views/settings/_security.haml
@@ -1,7 +1,7 @@
 .card
   .card-body
-    %h2= t('views.settings.security.2fa.title')
+    %h2= t(".heading")
     - if current_user.otp_module_disabled?
-      = render partial: 'settings/security/totp_setup', locals: { qr_svg: qr_svg }
+      = render partial: "settings/security/totp_setup", locals: { qr_svg: qr_svg }
     - else
-      = render partial: 'settings/security/totp_enabled', locals: { recovery_code_count: recovery_code_count }
+      = render partial: "settings/security/totp_enabled", locals: { recovery_code_count: recovery_code_count }

--- a/app/views/settings/security/_totp_enabled.haml
+++ b/app/views/settings/security/_totp_enabled.haml
@@ -1,6 +1,6 @@
-%p Your account is set up to require the use of a one-time password in order to log in.
-%p You currently have #{recovery_code_count} unused recovery codes.
-= button_to t('views.actions.remove'), destroy_user_2fa_path, class: 'btn btn-danger', method: 'delete',
-          data: { confirm: t('views.settings.security.2fa.detach_confirm') }
-= button_to 'Re-generate recovery codes', reset_user_recovery_codes_path, class: 'btn btn-primary', method: 'delete',
-          data: { confirm: 'Are you sure? This will disable your previous set of recovery codes.' }
+%p= t(".body")
+%p= t(".recovery_code_count", count: recovery_code_count)
+= button_to t(".remove.action"), destroy_user_2fa_path, class: "btn btn-danger", method: "delete",
+          data: { confirm: t(".remove.confirm") }
+= button_to t(".regenerate.action"), reset_user_recovery_codes_path, class: "btn btn-primary", method: "delete",
+          data: { confirm: t(".regenerate.confirm") }

--- a/app/views/settings/security/_totp_setup.haml
+++ b/app/views/settings/security/_totp_setup.haml
@@ -5,38 +5,37 @@
         .totp-setup__qr
           = qr_svg
         %p.totp-setup__text
-          If you cannot scan the QR code, use the following key instead:
-          %code= current_user.otp_secret_key.scan(/.{4}/).flatten.join(' ')
+          = t(".setup_key")
+          %code= current_user.otp_secret_key.scan(/.{4}/).flatten.join(" ")
     .totp-setup__content.col
       = bootstrap_form_for(current_user, url: { action: :update_2fa, method: :post }) do |f|
-        %p
-          If you do not have an authenticator app already installed on your device, we suggest one of the following:
+        %p= t(".app.none")
         %ul.list-unstyled.pl-3
           %li
             %i.fa.fa-android
-            Aegis Authenticator for Android
+            = t(".app.aegis")
             %ul.list-inline
               %li.list-inline-item
-                %a{ href: 'https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis' } Google Play
+                %a{ href: "https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis" }= t(".source.google_play")
               %li.list-inline-item
-                %a{ href: 'https://f-droid.org/app/com.beemdevelopment.aegis' } F-Droid
+                %a{ href: "https://f-droid.org/app/com.beemdevelopment.aegis" }= t(".source.fdroid")
               %li.list-inline-item
-                %a{ href: 'https://github.com/beemdevelopment/Aegis' } Source Code
+                %a{ href: "https://github.com/beemdevelopment/Aegis" }= t(".source.code")
           %li
             %i.fa.fa-apple
-            Strongbox Authenticator for iOS
+            = t(".app.strongbox")
             %ul.list-inline
               %li.list-inline-item
-                %a{ href: 'https://apps.apple.com/gb/app/strongbox-authenticator/id1023839880' } App Store
+                %a{ href: "https://apps.apple.com/gb/app/strongbox-authenticator/id1023839880" }= t(".source.app_store")
           %li
             %i.fa.fa-apple
             %i.fa.fa-android
-            Microsoft Authenticator
+            = t(".app.microsoft")
             %ul.list-inline
               %li.list-inline-item
-                %a{ href: 'https://apps.apple.com/gb/app/microsoft-authenticator/id983156458' } App Store
+                %a{ href: "https://apps.apple.com/gb/app/microsoft-authenticator/id983156458" }= t(".source.app_store")
               %li.list-inline-item
-                %a{ href: 'https://play.google.com/store/apps/details?id=com.azure.authenticator' } Google Play
-        %p Once you have downloaded an authenticator app, add your Retrospring account by scanning the QR code displayed on the left.
-        = f.text_field :otp_validation, class: 'totp-setup__code-field', label: 'Enter the code displayed in the app here:', autofocus: true
-        = f.submit t('views.actions.save'), class: 'btn btn-primary'
+                %a{ href: "https://play.google.com/store/apps/details?id=com.azure.authenticator" }= t(".source.google_play")
+        %p= t(".setup_qr", app_name: APP_CONFIG['site_name'])
+        = f.text_field :otp_validation, class: "totp-setup__code-field", label: t(".otp_validation"), autofocus: true
+        = f.primary

--- a/app/views/settings/security/recovery_keys.haml
+++ b/app/views/settings/security/recovery_keys.haml
@@ -5,19 +5,19 @@
         .card-body
           .d-none.d-print-block.totp-setup__recovery-icon
             %i.fa.fa-comments
-          %h1.totp-setup__recovery-title Your Retrospring recovery codes
+          %h1.totp-setup__recovery-title= t(".heading", app_name: APP_CONFIG['site_name'])
 
           %ul.totp-setup__recovery-codes
             - @recovery_keys.each do |key|
               %li
                 %code= key.code
-          .d-none.d-print-block These codes were generated #{Time.now.strftime('%F at %T %Z')}
+          .d-none.d-print-block= t(".generated_at", time: l(Time.now))
         .card-footer.d-print-none
-          We recommend storing these in a password manager or printing them out on paper.
+          = t(".recommendation")
           %br
-          %a.btn{ onclick: 'print()' }
+          %a.btn{ onclick: "print()" }
             %i.fa.fa-print
-            Print
+            = t(".print")
         .d-none.d-print-block.text-success
           %i.fa.fa-tree
-          Please consider the environment before printing this page.
+          = t(".consideration")

--- a/app/views/user/edit_security.haml
+++ b/app/views/user/edit_security.haml
@@ -1,4 +1,4 @@
-= render 'settings/security', qr_svg: @qr_svg, recovery_code_count: @recovery_code_count
+= render "settings/security", qr_svg: @qr_svg, recovery_code_count: @recovery_code_count
 
-- provide(:title, generate_title('Security Settings'))
-- parent_layout 'user/settings'
+- provide(:title, generate_title(t(".title")))
+- parent_layout "user/settings"

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -33,9 +33,16 @@ en:
       notice:
         profile_picture: " It might take a few minutes until your new profile picture is shown everywhere."
         profile_header: " It might take a few minutes until your new profile header is shown everywhere."
+    update_2fa:
+      error: :errors.invalid_otp
+    destroy_2fa:
+      success: "Two factor authentication has been disabled for your account."
     update_profile:
       success: :user.update.success
       error: :user.update.error
     update_theme:
       success: "Theme saved successfully."
       error: "Theme saving failed. %{errors}"
+    sessions:
+      create:
+        error: :errors.invalid_otp

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -45,4 +45,5 @@ en:
       error: "Theme saving failed. %{errors}"
     sessions:
       create:
+        info: "You have %{count} recovery codes remaining."
         error: :errors.invalid_otp

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,10 +371,6 @@ en:
         anonymous: "Allow anonymous questions"
         public: "Show your answers in the public timeline"
         stranger: "Allow other people to answer your questions"
-      security:
-        2fa:
-          title: "Two-factor authentication"
-          detach_confirm: "Are you sure you want to disable two-factor authentication?"
     modal:
       ask:
         title: "Ask your followers"
@@ -403,11 +399,3 @@ en:
         admin: "Admin"
         moderator: "Moderator"
         banned: "Banned"
-    auth:
-      2fa:
-        title: "Two-factor authentication"
-        otp_field: "One-time password"
-        errors:
-          invalid_code: "The code you entered was invalid."
-        setup:
-          success: "Two factor authentication has been enabled for your account."

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -20,3 +20,5 @@ en:
     user_not_found: "User not found"
 
     conflict: "This already exists"
+
+    invalid_otp: "The code you entered was invalid."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -1,4 +1,8 @@
 en:
+  auth:
+    two_factor_authentication:
+      heading: "Two-factor authentication"
+      otp_attempt: "Please enter the code from your authenticator app"
   announcement:
     index:
       title: :activerecord.models.announcement.other
@@ -55,6 +59,37 @@ en:
       adjust:
         profile_picture: "Adjust your new profile picture"
         profile_header: "Adjust your new profile header"
+    security:
+      heading: "Two-factor authentication"
+      recovery_keys:
+        heading: "Your %{app_name} recovery codes"
+        generated_at: "These codes were generated at %{time}"
+        recommendation: "We recommend storing these in a password manager or printing them out on paper."
+        print: "Print"
+        consideration: "Please consider the environment before printing this page."
+      totp_enabled:
+        body: "Your account is set up to require the use of a one-time password in order to log in."
+        recovery_code_count: "You currently have %{count} unused recovery codes."
+        remove:
+          action: "Remove Two-factor authentication"
+          confirm: "Are you sure you want to disable two-factor authentication?"
+        regenerate:
+          action: "Regenerate recovery codes"
+          confirm: "Are you sure? This will disable your previous set of recovery codes."
+      totp_setup:
+        setup_key: "If you cannot scan the QR code, use the following key instead:"
+        setup_qr: "Once you have downloaded an authenticator app, add your %{app_name} account by scanning the QR code displayed on the left."
+        otp_validation: "Enter the code displayed in the app here:"
+        app:
+          none: "If you do not have an authenticator app already installed on your device, we suggest one of the following:"
+          aegis: "Aegis Authenticator for Android"
+          strongbox: "Strongbox Authenticator for iOS"
+          microsoft: "Microsoft Authenticator"
+        source:
+          app_store: "App Store"
+          fdroid: "F-Droid"
+          google_play: "Google Play"
+          code: "Source Code"
     services:
       services:
         one: "Sharing is enabled for the following service:"
@@ -106,6 +141,8 @@ en:
   user:
     edit:
       title: "Profile Settings"
+    edit_security:
+      title: "Security Settings"
     edit_theme:
       title: "Theme Settings"
     export:

--- a/spec/controllers/user/sessions_controller_spec.rb
+++ b/spec/controllers/user/sessions_controller_spec.rb
@@ -68,7 +68,7 @@ describe User::SessionsController do
 
         it "redirects to the sign in page" do
           expect(subject).to redirect_to :new_user_session
-          expect(flash[:error]).to eq I18n.t('views.auth.2fa.errors.invalid_code')
+          expect(flash[:error]).to eq I18n.t("errors.invalid_otp")
         end
       end
     end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -253,7 +253,7 @@ describe UserController, type: :controller do
           Timecop.freeze(Time.at(1603290950)) do
             subject
             expect(response).to redirect_to :edit_user_security
-            expect(flash[:error]).to eq(I18n.t('views.auth.2fa.errors.invalid_code'))
+            expect(flash[:error]).to eq(I18n.t("errors.invalid_otp"))
           end
         end
       end


### PR DESCRIPTION
This adds (and moves) translations for everything security and 2FA-related.

**Testing:**
* Add 2FA to an account and check if all views are localized properly
* Log in to an account with 2FA and check if the views there are also localized properly
* Remove 2FA