### PR TITLE
typoed_email_validator: add new ending to the typo list

### DIFF
--- a/app/validators/typoed_email_validator.rb
+++ b/app/validators/typoed_email_validator.rb
@@ -6,6 +6,7 @@ class TypoedEmailValidator < ActiveModel::EachValidator
     # without @:
     ".con",
     ".coom",
+    ".mail",
 
     # with @:
     *%w[
@@ -15,15 +16,15 @@ class TypoedEmailValidator < ActiveModel::EachValidator
       gmaile.com
       gmaill.com
       gmali.com
+      hotmaill.com
       icluod.com
-      proton.mail
     ].map { "@#{_1}" }
   ].freeze
 
   def validate_each(record, attribute, value)
     return if valid?(value)
 
-    record.errors[attribute] << "contains a typo"
+    record.errors.add(attribute, :typo, message: "contains a typo")
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe User, type: :model do
     include_examples "valid email", "fritz.fantom@gmail.com"
     include_examples "valid email", "fritz.fantom@columbiamail.co"
     include_examples "valid email", "fritz.fantom@protonmail.com"
+    include_examples "valid email", "fritz.fantom@example.email"
     include_examples "valid email", "fritz.fantom@enterprise.k8s.420stripes.k8s.needs.more.k8s.jira.atlassian.k8s.eu-central-1.s3.amazonaws.com"
     include_examples "invalid email", "@jack"
 
@@ -72,6 +73,8 @@ RSpec.describe User, type: :model do
     include_examples "invalid email", "fritz.fantom@protonmail.con"
     # neither is .coom
     include_examples "invalid email", "fritz.fantom@gmail.coom"
+    # nor .mail (.email is, however)
+    include_examples "invalid email", "fritz.fantom@proton.mail"
     # common typos:
     include_examples "invalid email", "fritz.fantom@fmail.com"
     include_examples "invalid email", "fritz.fantom@gemail.com"
@@ -81,12 +84,11 @@ RSpec.describe User, type: :model do
     include_examples "invalid email", "fritz.fantom@gmaill.com"
     include_examples "invalid email", "fritz.fantom@gmali.com"
     include_examples "invalid email", "fritz.fantom@hotmailcom"
+    include_examples "invalid email", "fritz.fantom@hotmaill.com"
     include_examples "invalid email", "fritz.fantom@icluod.com"
     # no TLD
     include_examples "invalid email", "fritz.fantom@gmail"
     include_examples "invalid email", "fritz.fantom@protonmail"
-    # not registered as of 2022-01-11
-    include_examples "invalid email", "fritz.fantom@proton.mail"
   end
 
   # -- User::TimelineMethods --


### PR DESCRIPTION
also:
- consider '.mail' TLD a typo
- get rid of this deprecation warning: ``Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from validate_each at /Users/foxy/src/Retrospring/retrospring/app/validators/typoed_email_validator.rb:27)`` (as an added bonus: this should make it easier to translate!)