### PR TITLE
Increase in-feed answer display length

### DIFF
--- a/app/views/application/_answerbox.haml
+++ b/app/views/application/_answerbox.haml
@@ -5,8 +5,8 @@
   .card-body
     - if display_all.nil?
       .answerbox__answer-text
-        = markdown a.content[0..255]
-        - if a.content.length > 255
+        = markdown a.content[0..640]
+        - if a.content.length > 640
           [...]
           %p
             %a.btn.btn-primary{ href: show_user_answer_path(a.user.screen_name, a.id) }


### PR DESCRIPTION
Questions can be longer than answers in the feed. This increases answer display length to 640 characters (128 characters more than the 512 for questions)

This is mainly a "quick-fix" to show more content until we refactor the unfolding of content in general.