### PR TITLE
Configure better_errors to work in Docker environments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,3 +72,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
+
+# For better_errors to work inside Docker we need 
+# to allow 0.0.0.0 as an IP in development context
+BetterErrors::Middleware.allow_ip! "0.0.0.0/0"


### PR DESCRIPTION
It's been so long since I used `better_errors`, I want to have it back.