### PR TITLE
Add translations for footer

### DIFF
--- a/app/views/shared/_links.haml
+++ b/app/views/shared/_links.haml
@@ -1,12 +1,12 @@
 .text-center.text-muted.pb-3
   &copy;
   = Date.today.year
-  %span{ title: Retrospring::Version.to_s }= APP_CONFIG['site_name']
+  %span{ title: Retrospring::Version.to_s }= APP_CONFIG["site_name"]
   ·
-  = link_to t('views.general.about'), about_path
+  = link_to t('.about'), about_path
   ·
-  = link_to 'GitHub', 'https://github.com/Retrospring/retrospring'
+  = link_to t('.source'), 'https://github.com/Retrospring/retrospring'
   ·
-  = link_to t('views.general.terms'), terms_path
+  = link_to t('.terms'), terms_path
   ·
-  = link_to t('views.general.privacy'), privacy_policy_path
+  = link_to t('.privacy'), privacy_policy_path

--- a/app/views/shared/_links.haml
+++ b/app/views/shared/_links.haml
@@ -3,10 +3,10 @@
   = Date.today.year
   %span{ title: Retrospring::Version.to_s }= APP_CONFIG["site_name"]
   ·
-  = link_to t('.about'), about_path
+  = link_to t(".about"), about_path
   ·
-  = link_to t('.source'), 'https://github.com/Retrospring/retrospring'
+  = link_to t(".source"), "https://github.com/Retrospring/retrospring"
   ·
-  = link_to t('.terms'), terms_path
+  = link_to t(".terms"), terms_path
   ·
-  = link_to t('.privacy'), privacy_policy_path
+  = link_to t(".privacy"), privacy_policy_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,9 +219,6 @@ en:
       timeline: "Timeline"
       public: "Public"
       user: "User"
-      terms: "Terms of Service"
-      privacy: "Privacy Policy"
-      about: "About"
     list:
       title: "List"
       members: "Members"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -174,6 +174,12 @@ en:
         body: "Raised content basically describes all the different boxes and panels you can see across the site."
         accent:
           example: "Some text on top of a accented area on a raised element!"
+  shared:
+    links:
+      about: "About"
+      source: "Source code"
+      terms: "Terms of Service"
+      privacy: "Privacy Policy"
   static:
     about:
       title: "About"


### PR DESCRIPTION
Just a small one. Main difference is it saying "Source code" instead of GitHub now.

**Screenshot:**
![image](https://user-images.githubusercontent.com/1774242/163839942-ea3edb35-1e92-4838-8ded-f15da10a090c.png)

**Testing:**
* Look at the above screenshot/locales and give feedback
