### PR TITLE
Add translations for Inbox

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -20,7 +20,7 @@ class InboxController < ApplicationController
 
         if @inbox_author.empty?
           @empty = true
-          flash.now[:info] = "No questions from @#{params[:author]} found, showing default entries instead!"
+          flash.now[:info] = t(".author.info", author: params[:author])
         else
           @inbox = @inbox_author
           @inbox_count = @inbox_author_count
@@ -33,7 +33,7 @@ class InboxController < ApplicationController
         end
       rescue => e
         Sentry.capture_exception(e)
-        flash.now[:error] = "No user with the name @#{params[:author]} found, showing default entries instead!"
+        flash.now[:error] = t(".author.error", author: params[:author])
         @not_found = true
       end
     end

--- a/app/views/inbox/_entry.haml
+++ b/app/views/inbox/_entry.haml
@@ -1,4 +1,4 @@
-.card.inbox-entry{ class: i.new? ? 'inbox-entry--new' : '', data: { id: i.id } }
+.card.inbox-entry{ class: i.new? ? "inbox-entry--new" : "", data: { id: i.id } }
   .card-header
     .media
       - unless i.question.author_is_anonymous
@@ -6,11 +6,11 @@
           %img.answerbox__question-user-avatar.avatar-md{ src: i.question.user.profile_picture.url(:medium) }
       .media-body
         %h6.text-muted.media-heading.answerbox__question-user
-          = raw t('views.inbox.entry.asked', user: user_screen_name(i.question.user, anonymous: i.question.author_is_anonymous), time: time_tooltip(i.question))
+          = t(".asked_html", user: user_screen_name(i.question.user, anonymous: i.question.author_is_anonymous), time: time_tooltip(i.question))
           - if !i.question.author_is_anonymous && i.question.answer_count.positive?
             ·
             %a{ href: show_user_question_path(i.question.user.screen_name, i.question.id) }
-              = pluralize(i.question.answer_count, t('views.inbox.entry.response'))
+              = t(".answers", count: i.question.answer_count)
         .answerbox__question-text= question_markdown i.question.content
       - if i.question.user_id != current_user.id || current_user.has_role?(:administrator)
         .pull-right
@@ -19,32 +19,32 @@
               %span.caret
             .dropdown-menu.dropdown-menu-right{ role: :menu }
               - if i.question.user_id != current_user.id
-                %a.dropdown-item{ name: 'ib-report', data: { q_id: i.question.id } }
+                %a.dropdown-item{ name: "ib-report", data: { q_id: i.question.id } }
                   %i.fa.fa-warning
-                  = t 'views.actions.report'
+                  = t("voc.report")
               - if current_user.has_role? :administrator
                 %a.dropdown-item{ href: rails_admin_path_for_resource(i) }
                   %i.fa.fa-gears
-                  View in Kontrollzentrum
+                  = t("voc.view_in_rails_admin")
 
   .card-body
-    %textarea.form-control{ name: 'ib-answer', placeholder: t('views.placeholder.inbox'), data: { id: i.id } }
+    %textarea.form-control{ name: "ib-answer", placeholder: t(".placeholder"), data: { id: i.id } }
     %br/
-    %button.btn.btn-success{ name: 'ib-answer', data: { ib_id: i.id } }
-      = t 'views.actions.answer'
-    %button.btn.btn-danger{ name: 'ib-destroy', data: { ib_id: i.id } }
-      = t 'views.actions.delete'
-    %button.btn.btn-default{ name: 'ib-options', data: { ib_id: i.id, state: :hidden } }
+    %button.btn.btn-success{ name: "ib-answer", data: { ib_id: i.id } }
+      = t("voc.answer")
+    %button.btn.btn-danger{ name: "ib-destroy", data: { ib_id: i.id } }
+      = t("voc.delete")
+    %button.btn.btn-default{ name: "ib-options", data: { ib_id: i.id, state: :hidden } }
       %i.fa.fa-cog
-      %span.sr-only= t 'views.actions.options'
+      %span.sr-only= t(".options")
   .card-footer.d-none{ id: "ib-options-#{i.id}" }
-    %h4= t 'views.inbox.entry.sharing.title'
+    %h4= t(".sharing.heading")
     - if current_user.services.count.positive?
       .row
         - current_user.services.each do |service|
           .col-md-3.col-sm-4.col-xs-6
             %label
-              %input{ type: 'checkbox', name: 'ib-share', checked: :checked, data: { ib_id: i.id, service: service.provider } }
-              = raw t('views.inbox.entry.sharing.post', service: service.provider.capitalize)
+              %input{ type: "checkbox", name: "ib-share", checked: :checked, data: { ib_id: i.id, service: service.provider } }
+              = raw t(".sharing.post_to", service: service.provider.capitalize)
     - else
-      %p= raw t('views.inbox.entry.sharing.none', settings: link_to(t('views.inbox.entry.sharing.settings'), services_path))
+      %p= t(".sharing.none_html", settings: link_to(t(".sharing.settings"), services_path))

--- a/app/views/inbox/_sidebar.haml
+++ b/app/views/inbox/_sidebar.haml
@@ -1,27 +1,27 @@
 .card
-  .card-header= t 'views.inbox.sidebar.questions.title'
+  .card-header= t(".questions.heading")
   .card-body
-    %button.btn.btn-block.btn-info{ type: :button, id: 'ib-generate-question' }= t 'views.inbox.sidebar.questions.button'
+    %button.btn.btn-block.btn-info{ type: :button, id: "ib-generate-question" }= t(".questions.button")
 .card
-  .card-header= t 'views.inbox.sidebar.share.title'
+  .card-header= t(".share.heading")
   .card-body
-    %a.btn.btn-block.btn-primary{ target: '_blank',
+    %a.btn.btn-block.btn-primary{ target: "_blank",
       href: "https://twitter.com/intent/tweet?text=Ask%20me%20anything%21&url=#{show_user_profile_url(current_user.screen_name)}" }
       %i.fa.fa-fw.fa-twitter
-      = raw t('views.inbox.sidebar.share.button', service: 'Twitter')
-    %a.btn.btn-block.btn-primary{ target: '_blank',
+      = t(".share.button", service: "Twitter")
+    %a.btn.btn-block.btn-primary{ target: "_blank",
       href: "https://www.tumblr.com/share/link?url=#{show_user_profile_url(current_user.screen_name)}&name=Ask%20me%20anything%21" }
       %i.fa.fa-fw.fa-tumblr
-      = raw t('views.inbox.sidebar.share.button', service: 'Tumblr')
+      = t(".share.button", service: "Tumblr")
 .card
-  .card-header Show author
+  .card-header= t(".author.heading")
   .card-body
     %form#author-form
       = bootstrap_form_tag url: inbox_path, method: :get do |f|
-        = f.text_field :author, value: params[:author], placeholder: 'username', prepend: '@', hide_label: true
-        = f.button 'Show', name: nil, class: 'btn btn-light btn-block btn-sm', id: 'ib-author'
+        = f.text_field :author, value: params[:author], placeholder: t(".author.placeholder"), prepend: "@", hide_label: true
+        = f.button t(".author.button"), name: nil, class: "btn btn-light btn-block btn-sm", id: "ib-author"
 .card
-  .card-header= t 'views.inbox.sidebar.actions.title'
+  .card-header= t(".actions.heading")
   .card-body
     %button.btn.btn-block.btn-danger{ type: :button, id: delete_id, disabled: (disabled ? :disabled : nil), data: { ib_count: inbox_count } }
-      = t 'views.inbox.sidebar.actions.button'
+      = t(".actions.delete")

--- a/app/views/inbox/show.haml
+++ b/app/views/inbox/show.haml
@@ -1,14 +1,14 @@
 #entries
   - @inbox.each do |i|
-    = render 'inbox/entry', i: i
+    = render "inbox/entry", i: i
 
   - if @inbox.empty?
-    = t 'views.inbox.empty'
+    = t(".empty")
 
-= render 'shared/cursored_pagination_dummy', more_data_available: @more_data_available, last_id: @inbox_last_id
+= render "shared/cursored_pagination_dummy", more_data_available: @more_data_available, last_id: @inbox_last_id
 
 - if @more_data_available
 
   .d-flex.justify-content-center.justify-content-sm-start
     %button.btn.btn-light#load-more-btn{ type: :button, data: { last_id: @inbox_last_id } }
-      = t 'views.actions.load'
+      = t("vpc.load")

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -25,8 +25,8 @@ en:
       error: "Unable to delete announcement."
   inbox:
     author:
-      info: "No questions from @%{author} found, showing default entries instead!"
-      error: "No user with the name @%{author} found, showing default entries instead!"
+      info: "No questions from @%{author} found, showing entries from all users instead!"
+      error: "No user with the name @%{author} found, showing entries from all users instead!"
   services:
     create:
       success: "Service connected successfully."

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -23,6 +23,10 @@ en:
     destroy:
       success: "Announcement has been deleted successfully."
       error: "Unable to delete announcement."
+  inbox:
+    author:
+      info: "No questions from @%{author} found, showing default entries instead!"
+      error: "No user with the name @%{author} found, showing default entries instead!"
   services:
     create:
       success: "Service connected successfully."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,7 +161,6 @@ en:
     locale:
       languages: "Languages"
     placeholder:
-      inbox: "Write your answer here..."
       comment: "Comment..."
       question: "Type your question here…"
     notifications:
@@ -189,26 +188,6 @@ en:
         comment: "Comments"
         commentsmile: "Comment Smiles"
         relationship: "Followers"
-    inbox:
-      empty: "Nothing to see here."
-      sidebar:
-        questions:
-          title: "Out of questions?"
-          button: "Get new question"
-        share:
-          title: "Share"
-          button: "Share on %{service}"
-        actions:
-          title: "Actions"
-          button: "Delete all questions"
-      entry:
-        asked: "%{user} asked %{time} ago"
-        response: "response"
-        sharing:
-          title: "Sharing"
-          post: "Post to %{service}"
-          none: "You have not connected any services yet. Visit your %{settings} to connect one."
-          settings: "service settings"
     general:
       answer: "Answer"
       question: "Question"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -32,6 +32,20 @@ en:
   inbox:
     show:
       empty: "Nothing to see here."
+    sidebar:
+      actions:
+        heading: "Actions"
+        delete: "Delete all questions"
+      author:
+        heading: "Show author"
+        button: "Show"
+        placeholder: "username"
+      questions:
+        heading: "Out of questions?"
+        button: "Get new question"
+      share:
+        heading: "Share"
+        button: "Share on %{service}"
   modal:
     password:
       title: "Save account changes"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -29,6 +29,9 @@ en:
       title: "Bugs – Feedback"
     features:
       title: "Feature Requests – Feedback"
+  inbox:
+    show:
+      empty: "Nothing to see here."
   modal:
     password:
       title: "Save account changes"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -30,6 +30,18 @@ en:
     features:
       title: "Feature Requests – Feedback"
   inbox:
+    entry:
+      asked_html: "%{user} asked %{time} ago"
+      answers:
+        one: "1 answer"
+        other: "%{count} answers"
+      options: "Options"
+      placeholder: "Write your answer here..."
+      sharing:
+        heading: "Sharing"
+        post_to: "Post to %{service}"
+        none_html: "You have not connected any services yet. Visit your %{settings} to connect one."
+        settings: "service settings"
     show:
       empty: "Nothing to see here."
     sidebar:

--- a/config/locales/voc.en.yml
+++ b/config/locales/voc.en.yml
@@ -1,15 +1,19 @@
 en:
   voc:
+    answer: "Answer"
     cancel: "Cancel"
     close: "Close"
     confirm: "Are you sure?"
     delete: "Delete"
     edit: "Edit"
+    load: "Load more"
     login: "Sign in"
     save: "Save changes"
     register: "Sign up"
+    report: "Report"
     terms: "Terms of Service"
     update: "Update"
+    view_in_rails_admin: "View in Rails Admin"
   messages:
     noauth: "You must be signed in to do this."
   time:


### PR DESCRIPTION
Cleans up the inbox locales, adds the missing pieces here and there and fixes some mistakes done previously. Also removed a bunch of `raw` usages with `*_html` locales.

**Testing:**
* Check inbox if the locales look fine