### PR TITLE
Add block status identification on profiles

### DIFF
--- a/app/views/application/_questionbox.haml
+++ b/app/views/application/_questionbox.haml
@@ -8,6 +8,12 @@
     - if user.banned?
       .text-center
         %strong= t(".status.banned")
+    - elsif user_signed_in? && current_user.blocking?(user)
+      .text-center
+        %strong= t(".status.blocking")
+    - elsif user_signed_in? && user.blocking?(current_user)
+      .text-center
+        %strong= t(".status.blocked")
     - else
       - if user_signed_in? || user.privacy_allow_anonymous_questions?
         #question-box

--- a/app/views/application/_questionbox.haml
+++ b/app/views/application/_questionbox.haml
@@ -1,46 +1,46 @@
 .card
   .card-header
     - if user.profile.motivation_header.blank?
-      = t 'views.questionbox.title'
+      = t(".title")
     - else
       = user.profile.motivation_header
   .card-body
     - if user.banned?
       .text-center
-        %strong= t 'views.questionbox.banned'
+        %strong= t(".status.banned")
     - else
       - if user_signed_in? || user.privacy_allow_anonymous_questions?
         #question-box
-          %textarea.form-control{ name: 'qb-question', placeholder: t('views.placeholder.question') }
-          .row{ style: 'padding-top: 5px; padding-left: 5px; padding-right: 5px;' }
+          %textarea.form-control{ name: "qb-question", placeholder: t(".placeholder") }
+          .row{ style: "padding-top: 5px; padding-left: 5px; padding-right: 5px;" }
             .col-6
               - if user_signed_in?
                 - if user.privacy_allow_anonymous_questions?
-                  %input{ name: 'qb-anonymous', type: :checkbox }/
-                  = t 'views.actions.anonymous'
+                  %input{ name: "qb-anonymous", type: :checkbox }/
+                  = t(".anonymous")
                   %br/
                 - else
-                  %input{ name: 'qb-anonymous', type: :hidden, value: false }/
+                  %input{ name: "qb-anonymous", type: :hidden, value: false }/
             .col-6
               %p.pull-right
-                %input{ name: 'qb-to', type: 'hidden', value: user.id }/
-                %button.btn.btn-primary{ name: 'qb-ask',
+                %input{ name: "qb-to", type: "hidden", value: user.id }/
+                %button.btn.btn-primary{ name: "qb-ask",
                   type: :button,
-                  data: { loading_text: t('views.questionbox.load'), promote: user_signed_in? ? 'false' : 'true' } }
+                  data: { loading_text: t(".load"), promote: user_signed_in? ? "false" : "true" } }
                   Ask
       - unless user_signed_in?
         - if user.privacy_allow_anonymous_questions?
           .d-none#question-box-promote
             .row
               .col-12.text-center
-                %strong= t 'views.questionbox.promote.message'
+                %strong= t(".promote.message")
             .row
               .col-sm-5.offset-sm-1
-                %button.btn.btn-block.btn-primary#create-account= t 'views.questionbox.promote.create'
+                %button.btn.btn-block.btn-primary#create-account= t(".promote.create")
               .col-sm-5
-                %button.btn.btn-block.btn-default#new-question= t 'views.questionbox.promote.another'
+                %button.btn.btn-block.btn-default#new-question= t(".promote.another")
             .row
               .col-xs-12.col-sm-10.offset-sm-1.text-center
-                %small= t('views.questionbox.promote.join', app_title: APP_CONFIG['site_name'])
+                %small= t(".promote.join", app_title: APP_CONFIG["site_name"])
         - else
-          %p= raw t 'views.questionbox.required', signup: link_to(t('views.sessions.new'), new_user_registration_path)
+          %p= raw t(".required"), signup: link_to(t("views.sessions.new"), new_user_registration_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,7 +214,6 @@ en:
       ask_question: "Ask a question"
       answer: "Answer"
       options: "Options"
-      anonymous: "Hide your name"
       delete: "Delete"
       report: "Report"
       return: "Return to Inbox"
@@ -289,16 +288,6 @@ en:
       no_smile: "No one smiled this, yet."
       no_comment: "There are no comments yet."
       commentsmile: "People who smiled this comment"
-    questionbox:
-      title: "Ask something!"
-      banned: "This user got hit with ye olde banhammer."
-      required: "This user does not want to get asked by strangers.  Why don't you %{signup}?"
-      load: "Asking..."
-      promote:
-        message: "Your question has been sent."
-        create: "Create an account"
-        another: "Ask another question"
-        join: "Join %{app_title} today!  You'll be able to follow and ask people you know and a lot more."
     modal:
       ask:
         title: "Ask your followers"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -26,6 +26,8 @@ en:
         join: "Join %{app_title} today!  You'll be able to follow and ask people you know and a lot more."
       status:
         banned: "This user got hit with ye olde banhammer."
+        blocking: "You are blocking this user."
+        blocked: "This user has blocked you."
   devise:
     registrations:
       edit:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -12,6 +12,20 @@ en:
       title: "Create Announcement"
     edit:
       title: "Edit Announcement"
+  application:
+    questionbox:
+      title: "Ask something!"
+      required: "This user does not want to get asked by strangers.  Why don't you %{signup}?"
+      placeholder: "Type your question here…"
+      anonymous: "Hide your name"
+      load: "Asking…"
+      promote:
+        message: "Your question has been sent."
+        create: "Create an account"
+        another: "Ask another question"
+        join: "Join %{app_title} today!  You'll be able to follow and ask people you know and a lot more."
+      status:
+        banned: "This user got hit with ye olde banhammer."
   devise:
     registrations:
       edit:


### PR DESCRIPTION
Fixes up translations for the questionbox and also shows the block status in the questionbox (same as the ban-status)

![image](https://user-images.githubusercontent.com/1774242/173442990-045dc8f3-16e5-42d4-9a0f-a9c5fe7ebd72.png)

**Testing:**
* View a profile of a user that you have blocked
* View a profile of a user that blocked you
* View a profile without neither of the above two and check if the translations are still okay