### PR TITLE
Add interface to manage blocks

### DIFF
--- a/app/controllers/ajax/anonymous_block_controller.rb
+++ b/app/controllers/ajax/anonymous_block_controller.rb
@@ -31,7 +31,7 @@ class Ajax::AnonymousBlockController < AjaxController
     block.destroy!
 
     @response[:status] = :okay
-    @response[:message] = I18n.t("messages.block.create.okay")
+    @response[:message] = I18n.t("messages.block.destroy.okay")
     @response[:success] = true
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -223,4 +223,9 @@ class UserController < ApplicationController
     @rules = MuteRule.where(user: current_user)
   end
   # endregion
+
+  def edit_blocks
+    @blocks = Relationships::Block.where(source: current_user)
+    @anonymous_blocks = AnonymousBlock.where(user: current_user)
+  end
 end

--- a/app/javascript/retrospring/features/settings/block.ts
+++ b/app/javascript/retrospring/features/settings/block.ts
@@ -1,0 +1,27 @@
+import Rails from '@rails/ujs';
+import { showNotification, showErrorNotification } from 'utilities/notifications';
+import I18n from 'retrospring/i18n';
+
+export function unblockAnonymousHandler(event: Event): void {
+  const button: HTMLButtonElement = event.currentTarget as HTMLButtonElement;
+  const targetId = button.dataset.target;
+  let success = false;
+
+  Rails.ajax({
+    url: `/ajax/block_anon/${targetId}`,
+    type: 'DELETE',
+    success: (data) => {
+      success = data.success;
+      showNotification(data.message, data.success);
+    },
+    error: (data, status, xhr) => {
+      console.log(data, status, xhr);
+      showErrorNotification(I18n.translate('frontend.error.message'));
+    },
+    complete: () => {
+      if (!success) return;
+
+      button.closest('.list-group-item').remove();
+     }
+  });
+}

--- a/app/javascript/retrospring/features/settings/index.ts
+++ b/app/javascript/retrospring/features/settings/index.ts
@@ -3,6 +3,7 @@ import { muteDocumentHandler } from "./mute";
 import { profileHeaderChangeHandler, profilePictureChangeHandler } from "./crop";
 import { themeDocumentHandler, themeSubmitHandler } from "./theme";
 import { userSubmitHandler } from "./password";
+import { unblockAnonymousHandler } from "./block";
 
 export default (): void => {
   muteDocumentHandler();
@@ -12,6 +13,7 @@ export default (): void => {
     { type: 'submit', target: document.querySelector('#update_theme'), handler: themeSubmitHandler },
     { type: 'submit', target: document.querySelector('#edit_user'), handler: userSubmitHandler },
     { type: 'change', target: document.querySelector('#user_profile_picture[type=file]'), handler: profilePictureChangeHandler },
-    { type: 'change', target: document.querySelector('#user_profile_header[type=file]'), handler: profileHeaderChangeHandler }
+    { type: 'change', target: document.querySelector('#user_profile_header[type=file]'), handler: profileHeaderChangeHandler },
+    { type: 'click', target: document.querySelectorAll('[data-action="anon-unblock"]'), handler: unblockAnonymousHandler }
   ]);
 }

--- a/app/javascript/retrospring/features/user/action.ts
+++ b/app/javascript/retrospring/features/user/action.ts
@@ -61,15 +61,19 @@ export function userActionHandler(event: Event): void {
         case 'block':
           button.dataset.action = 'unblock';
           button.querySelector('span').innerText = I18n.translate('views.actions.unblock');
-          button.classList.remove('btn-primary');
-          button.classList.add('btn-default');
+          if (button.classList.contains('btn')) {
+            button.classList.remove('btn-primary');
+            button.classList.add('btn-default');
+          }
           resetFollowButton(document.querySelector<HTMLButtonElement>('button[data-action="unfollow"]'));
           break;
         case 'unblock':
           button.dataset.action = 'block';
           button.querySelector('span').innerText = I18n.translate('views.actions.block');
-          button.classList.remove('btn-default');
-          button.classList.add('btn-primary');
+          if (button.classList.contains('btn')) {
+            button.classList.remove('btn-default');
+            button.classList.add('btn-primary');
+          }
           break;
       }
      }

--- a/app/javascript/retrospring/features/user/index.ts
+++ b/app/javascript/retrospring/features/user/index.ts
@@ -5,7 +5,7 @@ import registerEvents from 'retrospring/utilities/registerEvents';
 export default (): void => {
   registerEvents([
     { type: 'click', target: 'button[name=user-action]', handler: userActionHandler, global: true },
-    { type: 'click', target: 'a[data-action=block], a[data-action=unblock]', handler: userActionHandler, global: true },
+    { type: 'click', target: '[data-action=block], [data-action=unblock]', handler: userActionHandler, global: true },
     { type: 'click', target: 'a[data-action=report-user]', handler: userReportHandler, global: true }
   ]);
 }

--- a/app/views/settings/_blocks.haml
+++ b/app/views/settings/_blocks.haml
@@ -13,6 +13,9 @@
             .ml-auto.d-inline-flex
               %button.btn.btn-default.align-self-center{ data: { action: :unblock, target: block.target.screen_name } }
                 %span.pe-none= t("views.actions.unblock")
+
+      - if @blocks.empty?
+        %p.text-muted.text-center= t(".none")
 .card
   .card-body
     %h2= t(".section.anon_blocks.heading")
@@ -28,3 +31,5 @@
               %button.btn.btn-default.align-self-center{ data: { action: "anon-unblock", target: block.id } }
                 %span.pe-none= t("views.actions.unblock")
 
+      - if @anonymous_blocks.empty?
+        %p.text-muted.text-center= t(".none")

--- a/app/views/settings/_blocks.haml
+++ b/app/views/settings/_blocks.haml
@@ -1,9 +1,7 @@
 .card
   .card-body
-    %h2 Blocks
-    %p 
-      Here every user you are currently blocking is listed with a quick option to unblock them. You can block users on their profile using the "Actions" dropdown.
-
+    %h2= t(".section.blocks.heading")
+    %p= t(".section.blocks.body")
     %ul.list-group
       - @blocks.each do |block|
         %li.list-group-item
@@ -11,30 +9,22 @@
             %img.avatar-md.d-none.d-sm-inline.mr-2{ src: block.target.profile_picture.url(:small) }
             %div
               %p.mb-0= user_screen_name(block.target)
-              %p.text-muted.mb-0
-                blocked
-                = time_ago_in_words(block.created_at)
-                ago
+              %p.text-muted.mb-0= t(".blocked", time: time_ago_in_words(block.created_at))
             .ml-auto.d-inline-flex
               %button.btn.btn-default.align-self-center{ data: { action: :unblock, target: block.target.screen_name } }
-                %span.pe-none Unblock
+                %span.pe-none= t("views.actions.unblock")
 .card
   .card-body
-    %h2 Anonymous Blocks
-    %p
-      Here every anonymous user you are blocking is listed with a quick option to unblock them. Anonymous users can be blocked from questions in your inbox. To provide
-      more context on who you blocked, the question they asked you is provided as context.
+    %h2= t(".section.anon_blocks.heading")
+    %p= t(".section.anon_blocks.body")
     %ul.list-group
       - @anonymous_blocks.each do |block|
         %li.list-group-item
           .d-flex
             %div
               %p.mb-0= block.question.content
-              %p.text-muted.mb-0
-                blocked
-                = time_ago_in_words(block.created_at)
-                ago
+              %p.text-muted.mb-0= t(".blocked", time: time_ago_in_words(block.created_at))
             .ml-auto.d-inline-flex
               %button.btn.btn-default.align-self-center{ data: { action: "anon-unblock", target: block.id } }
-                %span.pe-none Unblock
+                %span.pe-none= t("views.actions.unblock")
 

--- a/app/views/settings/_blocks.haml
+++ b/app/views/settings/_blocks.haml
@@ -1,0 +1,40 @@
+.card
+  .card-body
+    %h2 Blocks
+    %p 
+      Here every user you are currently blocking is listed with a quick option to unblock them. You can block users on their profile using the "Actions" dropdown.
+
+    %ul.list-group
+      - @blocks.each do |block|
+        %li.list-group-item
+          .d-flex
+            %img.avatar-md.d-none.d-sm-inline.mr-2{ src: block.target.profile_picture.url(:small) }
+            %div
+              %p.mb-0= user_screen_name(block.target)
+              %p.text-muted.mb-0
+                blocked
+                = time_ago_in_words(block.created_at)
+                ago
+            .ml-auto.d-inline-flex
+              %button.btn.btn-default.align-self-center{ data: { action: :unblock, target: block.target.screen_name } }
+                %span.pe-none Unblock
+.card
+  .card-body
+    %h2 Anonymous Blocks
+    %p
+      Here every anonymous user you are blocking is listed with a quick option to unblock them. Anonymous users can be blocked from questions in your inbox. To provide
+      more context on who you blocked, the question they asked you is provided as context.
+    %ul.list-group
+      - @anonymous_blocks.each do |block|
+        %li.list-group-item
+          .d-flex
+            %div
+              %p.mb-0= block.question.content
+              %p.text-muted.mb-0
+                blocked
+                = time_ago_in_words(block.created_at)
+                ago
+            .ml-auto.d-inline-flex
+              %button.btn.btn-default.align-self-center{ data: { action: "anon-unblock", target: block.id } }
+                %span.pe-none Unblock
+

--- a/app/views/tabs/_settings.haml
+++ b/app/views/tabs/_settings.haml
@@ -6,6 +6,7 @@
     = list_group_item t(".security"), edit_user_security_path
     = list_group_item t(".sharing"), services_path
     = list_group_item t(".mutes"), edit_user_mute_rules_path
+    = list_group_item t(".blocks"), edit_user_blocks_path
     = list_group_item t(".theme"), edit_user_theme_path
     = list_group_item t(".data"), user_data_path
     = list_group_item t(".export"), user_export_path

--- a/app/views/user/edit_blocks.haml
+++ b/app/views/user/edit_blocks.haml
@@ -1,0 +1,4 @@
+= render "settings/blocks"
+
+- provide(:title, generate_title(t(".title")))
+- parent_layout "user/settings"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -92,6 +92,15 @@ en:
       delete:
         action: "Delete my account"
         heading: "Unsatisfied?"
+    blocks:
+      blocked: "blocked %{time} ago"
+      section:
+        blocks:
+          heading: "Blocks"
+          body: "Here every user you are currently blocking is listed with a quick option to unblock them. You can block users on their profile using the 'Actions' dropdown."
+        anon_blocks:
+          heading: "Anonymous Blocks"
+          body: "Here every anonymous user you are blocking is listed with a quick option to unblock them. Anonymous users can be blocked from questions in your inbox. To provide more context on who you blocked, the question they asked you is provided as context."
     data:
       heading: "Your Profile Data"
       body: "Everything we have about you! Really, not that much as you might expect."
@@ -316,6 +325,8 @@ en:
       title: "Your Data"
     edit:
       title: "Profile Settings"
+    edit_blocks:
+      title: "Blocks"
     edit_mute:
       title: "Muted Words"
     edit_privacy:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -97,10 +97,10 @@ en:
       section:
         blocks:
           heading: "Blocks"
-          body: "Here every user you are currently blocking is listed with a quick option to unblock them. You can block users on their profile using the 'Actions' dropdown."
+          body: "Here every user you are currently blocking is listed with a quick option to unblock them. You can block users on their profile from the 'Actions' dropdown."
         anon_blocks:
           heading: "Anonymous Blocks"
-          body: "Here every anonymous user you are blocking is listed with a quick option to unblock them. Anonymous users can be blocked from questions in your inbox. To provide more context on who you blocked, the question they asked you is provided as context."
+          body: "Here every anonymous user you are blocking is listed with a quick option to unblock them. Anonymous users can be blocked from questions in your inbox. To provide more context on who you blocked, the question they asked you is shown."
     data:
       heading: "Your Profile Data"
       body: "Everything we have about you! Really, not that much as you might expect."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -98,7 +98,7 @@ en:
       section:
         blocks:
           heading: "Blocks"
-          body: "Here every user you are currently blocking is listed with a quick option to unblock them. You can block users on their profile from the 'Actions' dropdown."
+          body: "Each user you've blocked is listed here, along with a way to unblock them.  To block someone, use the 'Actions' dropdown on their profile page."
         anon_blocks:
           heading: "Anonymous Blocks"
           body: "Here every anonymous user you are blocking is listed with a quick option to unblock them. Anonymous users can be blocked from questions in your inbox. To provide more context on who you blocked, the question they asked you is shown."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -101,7 +101,7 @@ en:
           body: "Each user you've blocked is listed here, along with a way to unblock them.  To block someone, use the 'Actions' dropdown on their profile page."
         anon_blocks:
           heading: "Anonymous Blocks"
-          body: "Here every anonymous user you are blocking is listed with a quick option to unblock them. Anonymous users can be blocked from questions in your inbox. To provide more context on who you blocked, the question they asked you is shown."
+          body: "Each anonymous user you've blocked is listed here, along with a way to unblock them.  We also display the question they asked you to add some more context.  You can block anonymous users directly from the question in your inbox."
     data:
       heading: "Your Profile Data"
       body: "Everything we have about you! Really, not that much as you might expect."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -94,6 +94,7 @@ en:
         heading: "Unsatisfied?"
     blocks:
       blocked: "blocked %{time} ago"
+      none: "No one has been blocked yet"
       section:
         blocks:
           heading: "Blocks"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -94,7 +94,7 @@ en:
         heading: "Unsatisfied?"
     blocks:
       blocked: "blocked %{time} ago"
-      none: "No one has been blocked yet"
+      none: "You are not blocking anyone."
       section:
         blocks:
           heading: "Blocks"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
   match '/settings/security/2fa', to: 'user#destroy_2fa', via: :delete, as: :destroy_user_2fa
   match '/settings/security/recovery', to: 'user#reset_user_recovery_codes', via: :delete, as: :reset_user_recovery_codes
   match '/settings/muted', to: 'user#edit_mute', via: :get, as: :edit_user_mute_rules
+  match '/settings/blocks', to: 'user#edit_blocks', via: :get, as: :edit_user_blocks
 
   # resources :services, only: [:index, :destroy]
   match '/settings/services', to: 'services#index', via: 'get', as: :services

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -295,4 +295,37 @@ describe UserController, type: :controller do
       end
     end
   end
+
+  describe "#edit_blocks" do
+    subject { get :edit_blocks }
+
+    context "user signed in" do
+      before(:each) { sign_in user }
+
+      it "shows the edit_blocks page" do
+        subject
+        expect(response).to have_rendered(:edit_blocks)
+      end
+
+      it "only contains blocks of the signed in user" do
+        other_user = create(:user)
+        other_user.block(user)
+
+        subject
+
+        expect(assigns(:blocks)).to eq(user.active_block_relationships)
+      end
+
+      it "only contains anonymous blocks of the signed in user" do
+        other_user = create(:user)
+        question = create(:question)
+        other_user.anonymous_blocks.create(identifier: "very-real-identifier", question_id: question.id)
+
+        subject
+
+        expect(assigns(:anonymous_blocks)).to eq(user.anonymous_blocks)
+      end
+
+    end
+  end
 end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -325,7 +325,6 @@ describe UserController, type: :controller do
 
         expect(assigns(:anonymous_blocks)).to eq(user.anonymous_blocks)
       end
-
     end
   end
 end


### PR DESCRIPTION
Adds a `/settings/blocks` page to manage (anonymous) blocks, listing all blocked users and allowing to unblock them from there.

**Testing:**
* Check the new views if they look fine
* Check if the translations are applied fine
* Check if (un)blocking on user profiles and the block settings page still works