### PR TITLE
Fix various issues relating to user bans

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,11 +26,11 @@ class ApplicationController < ActionController::Base
       flash[:notice] = t('flash.ban.error', name: name)
       current_ban = current_user.bans.current.first
       unless current_ban&.reason.nil?
-        flash[:notice] += "\n#{t('flash.ban.reason', reason: current_user.bans.current.first.reason)}"
+        flash[:notice] += "\n#{t('flash.ban.reason', reason: current_ban.reason)}"
       end
-      unless current_ban&.permanently_banned?
+      unless current_ban&.permanent?
         # TODO format banned_until
-        flash[:notice] += "\n#{t('flash.ban.until', time: current_user.banned_until)}"
+        flash[:notice] += "\n#{t('flash.ban.until', time: current_ban.expires_at)}"
       end
       sign_out current_user
       redirect_to new_user_session_path

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -17,13 +17,19 @@ class StaticController < ApplicationController
   end
 
   def about
-    @users = User
-      .where.not(confirmed_at: nil)
-      .where(permanently_banned: false)
-      .where(banned_until: nil)
-      .where('answered_count > 0')
-      .count
+    user_count = User
+                 .where.not(confirmed_at: nil)
+                 .where("answered_count > 0")
+                 .count
 
+    current_ban_count = UserBan
+                        .current
+                        .joins(:user)
+                        .where.not("users.confirmed_at": nil)
+                        .where("users.answered_count > 0")
+                        .count
+
+    @users = user_count - current_ban_count
     @questions = Question.count
     @answers = Answer.count
     @comments = Comment.count

--- a/app/javascript/retrospring/features/moderation/ban.ts
+++ b/app/javascript/retrospring/features/moderation/ban.ts
@@ -36,7 +36,7 @@ export function banFormHandler(event: Event): void {
 
   if (checkbox && checkbox.checked) {
     data['ban'] = '1';
-    data['reason'] = form.elements['user'].value;
+    data['reason'] = form.elements['reason'].value;
 
     if (!permaCheckbox.checked) {
       data['duration'] = form.elements['duration'].value.trim();

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,9 +234,9 @@ class User < ApplicationRecord
   end
 
   def unban
-    UserBan.current.where(user_id: self.id).update_all(
+    bans.current.update(
       # -1s to account for flakyness with timings in tests
-      expires_at: DateTime.now - 1.second
+      expires_at: DateTime.now.utc - 1.second
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -229,6 +229,10 @@ class User < ApplicationRecord
   end
   # endregion
 
+  def permanently_banned?
+    bans.current.first&.permanent? || false
+  end
+
   def banned?
     self.bans.current.count > 0
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   include User::Relationship::Follow
   include User::Relationship::Block
   include User::AnswerMethods
+  include User::BanMethods
   include User::InboxMethods
   include User::QuestionMethods
   include User::RelationshipMethods
@@ -225,34 +226,6 @@ class User < ApplicationRecord
     ModerationComment.create!(user: self, report: report, content: content)
   end
   # endregion
-
-  def permanently_banned?
-    bans.current.first&.permanent? || false
-  end
-
-  def banned?
-    self.bans.current.count > 0
-  end
-
-  def unban
-    bans.current.update(
-      # -1s to account for flakyness with timings in tests
-      expires_at: DateTime.now.utc - 1.second
-    )
-  end
-
-  # Bans a user.
-  # @param expiry [DateTime, nil] the expiry time of the ban
-  # @param reason [String, nil] Reason for the ban. This is displayed to the user.
-  # @param banned_by [User] User who instated the ban
-  def ban(expiry = nil, reason = nil, banned_by = nil)
-    ::UserBan.create!(
-      user:       self,
-      expires_at: expiry,
-      banned_by:  banned_by,
-      reason:     reason
-    )
-  end
 
   def can_export?
     unless self.export_created_at.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,7 +234,10 @@ class User < ApplicationRecord
   end
 
   def unban
-    UseCase::User::Unban.call(id)
+    UserBan.current.where(user_id: self.id).update_all(
+      # -1s to account for flakyness with timings in tests
+      expires_at: DateTime.now - 1.second
+    )
   end
 
   # Bans a user.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,8 @@
+# frozen_string_literal: true
+
+require "use_case/user/ban"
+require "use_case/user/unban"
+
 class User < ApplicationRecord
   include User::Relationship
   include User::Relationship::Follow
@@ -233,21 +238,15 @@ class User < ApplicationRecord
   end
 
   # Bans a user.
-  # @param duration [Integer?] Ban duration
-  # @param duration_unit [String, nil] Unit for the <code>duration</code> parameter. Accepted units: hours, days, weeks, months
-  # @param reason [String] Reason for the ban. This is displayed to the user.
+  # @param expiry [DateTime, nil] the expiry time of the ban
+  # @param reason [String, nil] Reason for the ban. This is displayed to the user.
   # @param banned_by [User] User who instated the ban
-  def ban(duration, duration_unit = 'hours', reason = nil, banned_by = nil)
-    if duration
-      expiry = duration.public_send(duration_unit)
-    else
-      expiry = nil
-    end
-    UseCase::User::Ban.call(
-      target_user_id: id,
-      expiry: expiry,
-      reason: reason,
-      source_user_id: banned_by&.id
+  def ban(expiry = nil, reason = nil, banned_by = nil)
+    ::UserBan.create!(
+      user:       self,
+      expires_at: expiry,
+      banned_by:  banned_by,
+      reason:     reason
     )
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "use_case/user/ban"
-require "use_case/user/unban"
-
 class User < ApplicationRecord
   include User::Relationship
   include User::Relationship::Follow

--- a/app/models/user/ban_methods.rb
+++ b/app/models/user/ban_methods.rb
@@ -1,0 +1,29 @@
+module User::BanMethods
+  def permanently_banned?
+    bans.current.first&.permanent? || false
+  end
+
+  def banned?
+    self.bans.current.count > 0
+  end
+
+  def unban
+    bans.current.update(
+      # -1s to account for flakyness with timings in tests
+      expires_at: DateTime.now.utc - 1.second
+    )
+  end
+
+  # Bans a user.
+  # @param expiry [DateTime, nil] the expiry time of the ban
+  # @param reason [String, nil] Reason for the ban. This is displayed to the user.
+  # @param banned_by [User] User who instated the ban
+  def ban(expiry = nil, reason = nil, banned_by = nil)
+    ::UserBan.create!(
+      user:       self,
+      expires_at: expiry,
+      banned_by:  banned_by,
+      reason:     reason
+    )
+  end
+end

--- a/app/models/user/ban_methods.rb
+++ b/app/models/user/ban_methods.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module User::BanMethods
   def permanently_banned?
     bans.current.first&.permanent? || false
   end
 
   def banned?
-    self.bans.current.count > 0
+    bans.current.count.positive?
   end
 
   def unban

--- a/app/models/user_ban.rb
+++ b/app/models/user_ban.rb
@@ -1,6 +1,10 @@
 class UserBan < ApplicationRecord
   belongs_to :user
-  belongs_to :banned_by, class_name: 'User', optional: true
+  belongs_to :banned_by, class_name: "User", optional: true
 
-  scope :current, -> { where('expires_at IS NULL or expires_at > NOW()') }
+  scope :current, -> { where("expires_at IS NULL or expires_at > NOW()") }
+
+  def permanent?
+    expires_at.nil?
+  end
 end

--- a/app/views/modal/_ban.haml
+++ b/app/views/modal/_ban.haml
@@ -14,8 +14,8 @@
           .modal-body
             = f.check_box :ban, label: t('views.modal.bancontrol.ban'), checked: user.banned?
             #ban-controls{ class: user.banned? ? '' : 'd-none' }
-              = f.check_box :permaban, label: t('views.modal.bancontrol.permanent'), checked: user.permanent?
-              #ban-controls-time{ class: user.permanent? ? 'd-none' : '' }
+              = f.check_box :permaban, label: t('views.modal.bancontrol.permanent'), checked: user.permanently_banned?
+              #ban-controls-time{ class: user.permanently_banned? ? 'd-none' : '' }
                 = f.text_field :duration, label: '', required: true
                 .form-check.form-check-inline
                   = f.radio_button :duration_unit, 'hours', label: 'Hours', checked: true

--- a/app/views/modal/_ban.haml
+++ b/app/views/modal/_ban.haml
@@ -14,8 +14,8 @@
           .modal-body
             = f.check_box :ban, label: t('views.modal.bancontrol.ban'), checked: user.banned?
             #ban-controls{ class: user.banned? ? '' : 'd-none' }
-              = f.check_box :permaban, label: t('views.modal.bancontrol.permanent'), checked: user.permanently_banned?
-              #ban-controls-time{ class: user.permanently_banned? ? 'd-none' : '' }
+              = f.check_box :permaban, label: t('views.modal.bancontrol.permanent'), checked: user.permanent?
+              #ban-controls-time{ class: user.permanent? ? 'd-none' : '' }
                 = f.text_field :duration, label: '', required: true
                 .form-check.form-check-inline
                   = f.radio_button :duration_unit, 'hours', label: 'Hours', checked: true

--- a/db/migrate/20220626134554_remove_ban_related_field_from_users.rb
+++ b/db/migrate/20220626134554_remove_ban_related_field_from_users.rb
@@ -1,0 +1,7 @@
+class RemoveBanRelatedFieldFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :permanently_banned, :boolean, default: false
+    remove_column :users, :ban_reason, :string, default: nil
+    remove_column :users, :banned_until, :datetime, default: nil
+  end
+end

--- a/db/migrate/20220626134554_remove_ban_related_field_from_users.rb
+++ b/db/migrate/20220626134554_remove_ban_related_field_from_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveBanRelatedFieldFromUsers < ActiveRecord::Migration[6.1]
   def change
     remove_column :users, :permanently_banned, :boolean, default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_20_193732) do
+ActiveRecord::Schema.define(version: 2022_06_26_134554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -301,9 +301,6 @@ ActiveRecord::Schema.define(version: 2022_06_20_193732) do
     t.boolean "privacy_allow_public_timeline", default: true
     t.boolean "privacy_allow_stranger_answers", default: true
     t.boolean "privacy_show_in_search", default: true
-    t.boolean "permanently_banned", default: false
-    t.string "ban_reason"
-    t.datetime "banned_until"
     t.integer "comment_smiled_count", default: 0, null: false
     t.string "profile_header_file_name"
     t.boolean "profile_header_processing"

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -34,13 +34,13 @@ class Exporter
   private
 
   def collect_user_info
-    %i(answered_count asked_count comment_smiled_count commented_count
+    %i[answered_count asked_count comment_smiled_count commented_count
        confirmation_sent_at confirmed_at created_at profile_header profile_header_h profile_header_w profile_header_x profile_header_y
        profile_picture_w profile_picture_h profile_picture_x profile_picture_y current_sign_in_at current_sign_in_ip
        id last_sign_in_at last_sign_in_ip locale
        privacy_allow_anonymous_questions privacy_allow_public_timeline privacy_allow_stranger_answers
        privacy_show_in_search profile_header_file_name profile_picture_file_name
-       screen_name show_foreign_themes sign_in_count smiled_count updated_at).each do |f|
+       screen_name show_foreign_themes sign_in_count smiled_count updated_at].each do |f|
       @obj[f] = @user.send f
     end
 

--- a/lib/exporter.rb
+++ b/lib/exporter.rb
@@ -34,10 +34,10 @@ class Exporter
   private
 
   def collect_user_info
-    %i(answered_count asked_count ban_reason banned_until comment_smiled_count commented_count
+    %i(answered_count asked_count comment_smiled_count commented_count
        confirmation_sent_at confirmed_at created_at profile_header profile_header_h profile_header_w profile_header_x profile_header_y
        profile_picture_w profile_picture_h profile_picture_x profile_picture_y current_sign_in_at current_sign_in_ip
-       id last_sign_in_at last_sign_in_ip locale permanently_banned
+       id last_sign_in_at last_sign_in_ip locale
        privacy_allow_anonymous_questions privacy_allow_public_timeline privacy_allow_stranger_answers
        privacy_show_in_search profile_header_file_name profile_picture_file_name
        screen_name show_foreign_themes sign_in_count smiled_count updated_at).each do |f|

--- a/lib/use_case/user/ban.rb
+++ b/lib/use_case/user/ban.rb
@@ -15,12 +15,7 @@ module UseCase
       option :reason, type: Types::Coercible::String.optional
 
       def call
-        ban = ::UserBan.create!(
-          user: target_user,
-          expires_at: expiry,
-          banned_by: source_user,
-          reason: reason
-        )
+        ban = target_user.ban(expiry, reason, source_user)
 
         if reason == REASON_SPAM
           target_user.update!(

--- a/lib/use_case/user/unban.rb
+++ b/lib/use_case/user/unban.rb
@@ -8,10 +8,11 @@ module UseCase
       param :target_user_id, type: Types::Coercible::Integer
 
       def call
-        UserBan.current.where(user_id: target_user_id).update_all(
-          # -1s to account for flakyness with timings in tests
-          expires_at: DateTime.now - 1.second
-        )
+        target_user.unban
+      end
+
+      def target_user
+        @target_user ||= ::User.find(target_user_id)
       end
     end
   end

--- a/spec/controllers/ajax/moderation_controller_spec.rb
+++ b/spec/controllers/ajax/moderation_controller_spec.rb
@@ -421,10 +421,10 @@ describe Ajax::ModerationController, :ajax_controller, type: :controller do
             let(:duration_unit) { pb == '0' ? 'hours' : nil }
 
             context "when user is already banned" do
-              before { target_user.ban(nil) }
+              before { target_user.ban }
 
               it "unbans the user" do
-                 expect { subject }.to change { target_user.reload.banned? }.from(true).to(false)
+                expect { subject }.to change { target_user.reload.banned? }.from(true).to(false)
               end
 
               include_examples "returns the expected response"

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 describe StaticController, type: :controller do
   describe "#about" do
     subject { get :about }
-    
+
     before(:each) {
       FactoryBot.create(:user, { confirmed_at: Time.current, answered_count: 1 })
-      FactoryBot.create(:user, { permanently_banned: true })
-      FactoryBot.create(:user, { banned_until: Time.current + 10.days })
+      FactoryBot.create(:user, { confirmed_at: Time.current, answered_count: 1 }).ban
       FactoryBot.create(:user, { confirmed_at: Time.current })
+      FactoryBot.create(:user, { confirmed_at: Time.current }).ban
     }
 
     it "shows the correct user count" do

--- a/spec/lib/exporter_spec.rb
+++ b/spec/lib/exporter_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require 'exporter'
+require "rails_helper"
+require "exporter"
 
 RSpec.describe Exporter do
   let(:params) { {
     answered_count: 144,
     asked_count: 72,
-    ban_reason: nil,
-    banned_until: nil,
     comment_smiled_count: 15,
     commented_count: 12,
     confirmation_sent_at: 2.weeks.ago.utc,
@@ -19,7 +17,6 @@ RSpec.describe Exporter do
     last_sign_in_at: 1.hour.ago,
     last_sign_in_ip: '192.0.2.14',
     locale: 'en',
-    permanently_banned: false,
     privacy_allow_anonymous_questions: true,
     privacy_allow_public_timeline: false,
     privacy_allow_stranger_answers: false,


### PR DESCRIPTION
- Fixes ban reasons being set to the screen name of the user being banned
- Fixes banned users unable to logged in (Sentry: `RETROSPRING-3K`)
- Adds tests for attempting to log in while banned
- Moves creation and invalidation of user bans into `User#ban` and `User#unban`
- Removes legacy ban-related fields from the `users` table
- Updates the user count shown on the About to account for the amount of banned users
