### PR TITLE
Move final settings actions into their own `SettingsController`s

### DIFF
--- a/app/controllers/settings/blocks_controller.rb
+++ b/app/controllers/settings/blocks_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Settings::BlocksController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @blocks = Relationships::Block.where(source: current_user)
+    @anonymous_blocks = AnonymousBlock.where(user: current_user)
+  end
+end

--- a/app/controllers/settings/data_controller.rb
+++ b/app/controllers/settings/data_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Settings::DataController < ApplicationController
+  before_action :authenticate_user!
+
+  def index; end
+end

--- a/app/controllers/settings/mutes_controller.rb
+++ b/app/controllers/settings/mutes_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Settings::MutesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @rules = MuteRule.where(user: current_user)
+  end
+end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,6 +1,4 @@
 class UserController < ApplicationController
-  before_action :authenticate_user!, only: %w[data]
-
   def show
     @user = User.where('LOWER(screen_name) = ?', params[:username].downcase).includes(:profile).first!
     @answers = @user.cursored_answers(last_id: params[:last_id])
@@ -64,8 +62,5 @@ class UserController < ApplicationController
       format.html
       format.js { render layout: false }
     end
-  end
-
-  def data
   end
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,5 +1,5 @@
 class UserController < ApplicationController
-  before_action :authenticate_user!, only: %w[data edit_mute edit_blocks]
+  before_action :authenticate_user!, only: %w[data edit_blocks]
 
   def show
     @user = User.where('LOWER(screen_name) = ?', params[:username].downcase).includes(:profile).first!
@@ -68,12 +68,6 @@ class UserController < ApplicationController
 
   def data
   end
-
-  # region Muting
-  def edit_mute
-    @rules = MuteRule.where(user: current_user)
-  end
-  # endregion
 
   def edit_blocks
     @blocks = Relationships::Block.where(source: current_user)

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,5 +1,5 @@
 class UserController < ApplicationController
-  before_action :authenticate_user!, only: %w[data edit_blocks]
+  before_action :authenticate_user!, only: %w[data]
 
   def show
     @user = User.where('LOWER(screen_name) = ?', params[:username].downcase).includes(:profile).first!
@@ -67,10 +67,5 @@ class UserController < ApplicationController
   end
 
   def data
-  end
-
-  def edit_blocks
-    @blocks = Relationships::Block.where(source: current_user)
-    @anonymous_blocks = AnonymousBlock.where(user: current_user)
   end
 end

--- a/app/views/settings/blocks/index.haml
+++ b/app/views/settings/blocks/index.haml
@@ -33,3 +33,6 @@
 
       - if @anonymous_blocks.empty?
         %p.text-muted.text-center= t(".none")
+
+- provide(:title, generate_title(t(".title")))
+- parent_layout "user/settings"

--- a/app/views/settings/data/index.haml
+++ b/app/views/settings/data/index.haml
@@ -102,3 +102,6 @@
             = " (#{t('time.distance_ago', time: time_ago_in_words(current_user.updated_at))})"
           - else
             = t(".none")
+
+- provide(:title, generate_title(t(".title")))
+- parent_layout "user/settings"

--- a/app/views/settings/mutes/index.haml
+++ b/app/views/settings/mutes/index.haml
@@ -22,3 +22,6 @@
       %input.form-control{ disabled: true }
       .input-group-append
         %button.btn.btn-danger{ type: "button" }= t(".actions.remove")
+
+- provide(:title, generate_title(t(".title")))
+- parent_layout "user/settings"

--- a/app/views/tabs/_settings.haml
+++ b/app/views/tabs/_settings.haml
@@ -8,7 +8,7 @@
     = list_group_item t(".mutes"), settings_muted_path
     = list_group_item t(".blocks"), settings_blocks_path
     = list_group_item t(".theme"), settings_theme_path
-    = list_group_item t(".data"), user_data_path
+    = list_group_item t(".data"), settings_data_path
     = list_group_item t(".export"), settings_export_path
 
 .d-none.d-sm-block= render "shared/links"

--- a/app/views/tabs/_settings.haml
+++ b/app/views/tabs/_settings.haml
@@ -1,13 +1,13 @@
 .card
   .list-group
     = list_group_item t(".account"), edit_user_registration_path
-    = list_group_item t(".profile"), settings_profile_path
-    = list_group_item t(".privacy"), settings_privacy_path
+    = list_group_item t(".profile"), edit_settings_profile_path
+    = list_group_item t(".privacy"), edit_settings_privacy_path
     = list_group_item t(".security"), settings_two_factor_authentication_otp_authentication_path
     = list_group_item t(".sharing"), services_path
     = list_group_item t(".mutes"), settings_muted_path
     = list_group_item t(".blocks"), settings_blocks_path
-    = list_group_item t(".theme"), settings_theme_path
+    = list_group_item t(".theme"), edit_settings_theme_path
     = list_group_item t(".data"), settings_data_path
     = list_group_item t(".export"), settings_export_path
 

--- a/app/views/tabs/_settings.haml
+++ b/app/views/tabs/_settings.haml
@@ -6,7 +6,7 @@
     = list_group_item t(".security"), settings_two_factor_authentication_otp_authentication_path
     = list_group_item t(".sharing"), services_path
     = list_group_item t(".mutes"), settings_muted_path
-    = list_group_item t(".blocks"), edit_user_blocks_path
+    = list_group_item t(".blocks"), settings_blocks_path
     = list_group_item t(".theme"), settings_theme_path
     = list_group_item t(".data"), user_data_path
     = list_group_item t(".export"), settings_export_path

--- a/app/views/tabs/_settings.haml
+++ b/app/views/tabs/_settings.haml
@@ -5,7 +5,7 @@
     = list_group_item t(".privacy"), settings_privacy_path
     = list_group_item t(".security"), settings_two_factor_authentication_otp_authentication_path
     = list_group_item t(".sharing"), services_path
-    = list_group_item t(".mutes"), edit_user_mute_rules_path
+    = list_group_item t(".mutes"), settings_muted_path
     = list_group_item t(".blocks"), edit_user_blocks_path
     = list_group_item t(".theme"), settings_theme_path
     = list_group_item t(".data"), user_data_path

--- a/app/views/user/data.haml
+++ b/app/views/user/data.haml
@@ -1,4 +1,0 @@
-= render "settings/data"
-
-- provide(:title, generate_title(t(".title")))
-- parent_layout "user/settings"

--- a/app/views/user/edit_blocks.haml
+++ b/app/views/user/edit_blocks.haml
@@ -1,4 +1,0 @@
-= render "settings/blocks"
-
-- provide(:title, generate_title(t(".title")))
-- parent_layout "user/settings"

--- a/app/views/user/edit_mute.haml
+++ b/app/views/user/edit_mute.haml
@@ -1,4 +1,0 @@
-= render "settings/muted"
-
-- provide(:title, generate_title(t(".title")))
-- parent_layout "user/settings"

--- a/app/views/user/edit_security.haml
+++ b/app/views/user/edit_security.haml
@@ -1,4 +1,0 @@
-= render "settings/security", qr_svg: @qr_svg, recovery_code_count: @recovery_code_count
-
-- provide(:title, generate_title(t(".title")))
-- parent_layout "user/settings"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -114,15 +114,17 @@ en:
         action: "Delete my account"
         heading: "Unsatisfied?"
     blocks:
-      blocked: "blocked %{time} ago"
-      none: "You are not blocking anyone."
-      section:
-        blocks:
-          heading: "Blocks"
-          body: "Each user you've blocked is listed here, along with a way to unblock them.  To block someone, use the 'Actions' dropdown on their profile page."
-        anon_blocks:
-          heading: "Anonymous Blocks"
-          body: "Each anonymous user you've blocked is listed here, along with a way to unblock them.  We also display the question they asked you to add some more context.  You can block anonymous users directly from the question in your inbox."
+      index:
+        title: "Blocks"
+        blocked: "blocked %{time} ago"
+        none: "You are not blocking anyone."
+        section:
+          blocks:
+            heading: "Blocks"
+            body: "Each user you've blocked is listed here, along with a way to unblock them.  To block someone, use the 'Actions' dropdown on their profile page."
+          anon_blocks:
+            heading: "Anonymous Blocks"
+            body: "Each anonymous user you've blocked is listed here, along with a way to unblock them.  We also display the question they asked you to add some more context.  You can block anonymous users directly from the question in your inbox."
     data:
       heading: "Your Profile Data"
       body: "Everything we have about you! Really, not that much as you might expect."
@@ -359,8 +361,6 @@ en:
   user:
     data:
       title: "Your Data"
-    edit_blocks:
-      title: "Blocks"
   moderation:
     inbox:
       header:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -165,13 +165,15 @@ en:
         export_url:
           none: "Once exporting your account is done, a download link will appear here."
           present: "Here's your export from %{time}"
-    muted:
-      heading: "Muted words"
-      body: "Muting words (or longer phrases) will prevent questions containing those to appear in your inbox."
-      note: "Note: Filtered questions are discarded completely from your inbox, and won't reappear if you remove a filter later on."
-      placeholder: "Add a new muted word..."
-      actions:
-        add: "Add"
+    mutes:
+      index:
+        title: "Muted Words"
+        heading: "Muted words"
+        body: "Muting words (or longer phrases) will prevent questions containing those to appear in your inbox."
+        note: "Note: Filtered questions are discarded completely from your inbox, and won't reappear if you remove a filter later on."
+        placeholder: "Add a new muted word..."
+        actions:
+          add: "Add"
         remove: "Remove"
     privacy:
       edit:
@@ -359,8 +361,6 @@ en:
       title: "Your Data"
     edit_blocks:
       title: "Blocks"
-    edit_mute:
-      title: "Muted Words"
   moderation:
     inbox:
       header:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -126,33 +126,35 @@ en:
             heading: "Anonymous Blocks"
             body: "Each anonymous user you've blocked is listed here, along with a way to unblock them.  We also display the question they asked you to add some more context.  You can block anonymous users directly from the question in your inbox."
     data:
-      heading: "Your Profile Data"
-      body: "Everything we have about you! Really, not that much as you might expect."
-      none: "None set!"
-      section:
-        general: "General"
-        profile: "Profile"
-        pictures: "Pictures"
-        ip: "IP"
-        miscellaneous: "Miscellaneous"
-        dates: "Dates"
-        sign_in: "Sign In"
-        create_update: "Create/Update"
-      pictures:
-        profile_picture:
-          heading: "Profile picture"
-          size:
-            small: "Small"
-            medium: "Medium"
-            large: "Large"
-            original: "Original image"
-        profile_header:
-          heading: "Profile header"
-          size:
-            mobile: "Mobile"
-            web: "Web"
-            retina: "Retina"
-            original: "Original image"
+      index:
+        title: "Your Data"
+        heading: "Your Profile Data"
+        body: "Everything we have about you! Really, not that much as you might expect."
+        none: "None set!"
+        section:
+          general: "General"
+          profile: "Profile"
+          pictures: "Pictures"
+          ip: "IP"
+          miscellaneous: "Miscellaneous"
+          dates: "Dates"
+          sign_in: "Sign In"
+          create_update: "Create/Update"
+        pictures:
+          profile_picture:
+            heading: "Profile picture"
+            size:
+              small: "Small"
+              medium: "Medium"
+              large: "Large"
+              original: "Original image"
+          profile_header:
+            heading: "Profile header"
+            size:
+              mobile: "Mobile"
+              web: "Web"
+              retina: "Retina"
+              original: "Original image"
     export:
       index:
         title: "Export"
@@ -358,9 +360,6 @@ en:
       theme: "Theme"
       data: "Your Data"
       export: "Export"
-  user:
-    data:
-      title: "Your Data"
   moderation:
     inbox:
       header:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,8 @@ Rails.application.routes.draw do
 
     get :blocks, to: 'blocks#index'
 
+    get :data, to: 'data#index'
+
     namespace :two_factor_authentication do
       get :otp_authentication, to: 'otp_authentication#index'
       patch :otp_authentication, to: 'otp_authentication#update'
@@ -90,8 +92,6 @@ Rails.application.routes.draw do
   end
   resolve('Theme') { [:settings_theme] } # to make link_to/form_for work nicely when passing a `Theme` object to it, see also: https://api.rubyonrails.org/v6.1.5.1/classes/ActionDispatch/Routing/Mapper/CustomUrls.html#method-i-resolve
   resolve('Profile') { [:settings_profile] }
-
-  match '/settings/blocks', to: 'user#edit_blocks', via: :get, as: :edit_user_blocks
 
   # resources :services, only: [:index, :destroy]
   match '/settings/services', to: 'services#index', via: 'get', as: :services
@@ -103,8 +103,6 @@ Rails.application.routes.draw do
       get :failure
     end
   end
-
-  match '/settings/data', to: 'user#data', via: :get, as: :user_data
 
   namespace :ajax do
     match '/ask', to: 'question#create', via: :post, as: :ask

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,8 @@ Rails.application.routes.draw do
     get :export, to: 'export#index'
     post :export, to: 'export#create'
 
+    get :muted, to: 'mutes#index'
+
     namespace :two_factor_authentication do
       get :otp_authentication, to: 'otp_authentication#index'
       patch :otp_authentication, to: 'otp_authentication#update'
@@ -87,7 +89,6 @@ Rails.application.routes.draw do
   resolve('Theme') { [:settings_theme] } # to make link_to/form_for work nicely when passing a `Theme` object to it, see also: https://api.rubyonrails.org/v6.1.5.1/classes/ActionDispatch/Routing/Mapper/CustomUrls.html#method-i-resolve
   resolve('Profile') { [:settings_profile] }
 
-  match '/settings/muted', to: 'user#edit_mute', via: :get, as: :edit_user_mute_rules
   match '/settings/blocks', to: 'user#edit_blocks', via: :get, as: :edit_user_blocks
 
   # resources :services, only: [:index, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
 
     get :muted, to: 'mutes#index'
 
+    get :blocks, to: 'blocks#index'
+
     namespace :two_factor_authentication do
       get :otp_authentication, to: 'otp_authentication#index'
       patch :otp_authentication, to: 'otp_authentication#update'

--- a/spec/controllers/settings/blocks_controller_spec.rb
+++ b/spec/controllers/settings/blocks_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Settings::BlocksController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "#index" do
+    subject { get :index }
+
+    context "user signed in" do
+      before(:each) { sign_in user }
+
+      it "shows the edit_blocks page" do
+        subject
+        expect(response).to have_rendered(:index)
+      end
+
+      it "only contains blocks of the signed in user" do
+        other_user = create(:user)
+        other_user.block(user)
+
+        subject
+
+        expect(assigns(:blocks)).to eq(user.active_block_relationships)
+      end
+
+      it "only contains anonymous blocks of the signed in user" do
+        other_user = create(:user)
+        question = create(:question)
+        other_user.anonymous_blocks.create(identifier: "very-real-identifier", question_id: question.id)
+
+        subject
+
+        expect(assigns(:anonymous_blocks)).to eq(user.anonymous_blocks)
+      end
+    end
+  end
+end

--- a/spec/controllers/settings/data_controller_spec.rb
+++ b/spec/controllers/settings/data_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Settings::DataController, type: :controller do
+  describe "#index" do
+    subject { get :index }
+
+    context "user signed in" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before { sign_in user }
+
+      it "shows the index page" do
+        subject
+        expect(response).to have_rendered(:index)
+      end
+    end
+  end
+end

--- a/spec/controllers/settings/mutes_controller_spec.rb
+++ b/spec/controllers/settings/mutes_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Settings::MutesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "#index" do
+    subject { get :index }
+
+    context "user signed in" do
+      before(:each) { sign_in user }
+
+      it "shows the edit_blocks page" do
+        subject
+        expect(response).to have_rendered(:index)
+      end
+
+      it "only contains blocks of the signed in user" do
+        other_user = create(:user)
+        other_user.block(user)
+
+        subject
+
+        expect(assigns(:blocks)).to eq(user.active_block_relationships)
+      end
+
+      it "only contains anonymous blocks of the signed in user" do
+        other_user = create(:user)
+        question = create(:question)
+        other_user.anonymous_blocks.create(identifier: "very-real-identifier", question_id: question.id)
+
+        subject
+
+        expect(assigns(:anonymous_blocks)).to eq(user.anonymous_blocks)
+      end
+    end
+  end
+end

--- a/spec/controllers/settings/mutes_controller_spec.rb
+++ b/spec/controllers/settings/mutes_controller_spec.rb
@@ -3,36 +3,17 @@
 require "rails_helper"
 
 describe Settings::MutesController, type: :controller do
-  let(:user) { FactoryBot.create(:user) }
-
   describe "#index" do
     subject { get :index }
 
     context "user signed in" do
-      before(:each) { sign_in user }
+      let(:user) { FactoryBot.create(:user) }
 
-      it "shows the edit_blocks page" do
+      before { sign_in user }
+
+      it "shows the index page" do
         subject
         expect(response).to have_rendered(:index)
-      end
-
-      it "only contains blocks of the signed in user" do
-        other_user = create(:user)
-        other_user.block(user)
-
-        subject
-
-        expect(assigns(:blocks)).to eq(user.active_block_relationships)
-      end
-
-      it "only contains anonymous blocks of the signed in user" do
-        other_user = create(:user)
-        question = create(:question)
-        other_user.anonymous_blocks.create(identifier: "very-real-identifier", question_id: question.id)
-
-        subject
-
-        expect(assigns(:anonymous_blocks)).to eq(user.anonymous_blocks)
       end
     end
   end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -62,36 +62,4 @@ describe UserController, type: :controller do
       end
     end
   end
-
-  describe "#edit_blocks" do
-    subject { get :edit_blocks }
-
-    context "user signed in" do
-      before(:each) { sign_in user }
-
-      it "shows the edit_blocks page" do
-        subject
-        expect(response).to have_rendered(:edit_blocks)
-      end
-
-      it "only contains blocks of the signed in user" do
-        other_user = create(:user)
-        other_user.block(user)
-
-        subject
-
-        expect(assigns(:blocks)).to eq(user.active_block_relationships)
-      end
-
-      it "only contains anonymous blocks of the signed in user" do
-        other_user = create(:user)
-        question = create(:question)
-        other_user.anonymous_blocks.create(identifier: "very-real-identifier", question_id: question.id)
-
-        subject
-
-        expect(assigns(:anonymous_blocks)).to eq(user.anonymous_blocks)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Final stretch! Closes #415

This PR moves `edit_blocks`, `edit_mutes` and `data` into their own controllers.

**Testing:**
* Make sure the views and locales work, dynamic functionality should be unchanged as the TS was not touched.