### PR TITLE
Add translations for AJAX controllers

### DIFF
--- a/app/controllers/ajax/anonymous_block_controller.rb
+++ b/app/controllers/ajax/anonymous_block_controller.rb
@@ -15,7 +15,7 @@ class Ajax::AnonymousBlockController < AjaxController
     question.inboxes.first.destroy
 
     @response[:status] = :okay
-    @response[:message] = I18n.t("messages.block.create.okay")
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -25,13 +25,13 @@ class Ajax::AnonymousBlockController < AjaxController
     block = AnonymousBlock.find(params[:id])
     if current_user != block.user
       @response[:status] = :nopriv
-      @response[:message] = I18n.t("messages.block.destroy.nopriv")
+      @response[:message] = t(".nopriv")
     end
 
     block.destroy!
 
     @response[:status] = :okay
-    @response[:message] = I18n.t("messages.block.destroy.okay")
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/answer_controller.rb
+++ b/app/controllers/ajax/answer_controller.rb
@@ -12,7 +12,7 @@ class Ajax::AnswerController < AjaxController
 
       unless current_user == inbox_entry.user
         @response[:status] = :fail
-        @response[:message] = I18n.t('messages.answer.create.fail')
+        @response[:message] = t(".error")
         return
       end
     else
@@ -20,16 +20,9 @@ class Ajax::AnswerController < AjaxController
 
       unless question.user.privacy_allow_stranger_answers
         @response[:status] = :privacy_stronk
-        @response[:message] = I18n.t('messages.answer.create.privacy_stronk')
+        @response[:message] = t(".privacy")
         return
       end
-    end
-
-    # this should never trigger because empty params throw ParameterMissing
-    unless params[:answer].length > 0
-      @response[:status] = :peter_dinklage
-      @response[:message] = I18n.t('messages.answer.create.peter_dinklage')
-      return
     end
 
     answer = if inbox
@@ -45,7 +38,7 @@ class Ajax::AnswerController < AjaxController
 
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.answer.create.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
     unless inbox
       # this assign is needed because shared/_answerbox relies on it, I think
@@ -61,7 +54,7 @@ class Ajax::AnswerController < AjaxController
 
     unless (current_user == answer.user) or (privileged? answer.user)
       @response[:status] = :nopriv
-      @response[:message] = I18n.t('messages.answer.destroy.nopriv')
+      @response[:message] = t(".nopriv")
       return
     end
 
@@ -71,7 +64,7 @@ class Ajax::AnswerController < AjaxController
     answer.destroy
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.answer.destroy.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/comment_controller.rb
+++ b/app/controllers/ajax/comment_controller.rb
@@ -10,12 +10,12 @@ class Ajax::CommentController < AjaxController
     rescue ActiveRecord::RecordInvalid => e
       Sentry.capture_exception(e)
       @response[:status] = :rec_inv
-      @response[:message] = I18n.t('messages.comment.create.rec_inv')
+      @response[:message] = t(".invalid")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.comment.create.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
     @response[:render] = render_to_string(partial: 'answerbox/comments', locals: { a: answer })
     @response[:count] = answer.comment_count
@@ -29,7 +29,7 @@ class Ajax::CommentController < AjaxController
 
     unless (current_user == comment.user) or (current_user == comment.answer.user) or (privileged? comment.user)
       @response[:status] = :nopriv
-      @response[:message] = I18n.t('messages.comment.destroy.nopriv')
+      @response[:message] = t(".nopriv")
       return
     end
 
@@ -37,7 +37,7 @@ class Ajax::CommentController < AjaxController
     comment.destroy
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.comment.destroy.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/inbox_controller.rb
+++ b/app/controllers/ajax/inbox_controller.rb
@@ -2,7 +2,7 @@ class Ajax::InboxController < AjaxController
   def create
     unless user_signed_in?
       @response[:status] = :noauth
-      @response[:message] = I18n.t('messages.noauth')
+      @response[:message] = t(".noauth")
       return
     end
 
@@ -14,7 +14,7 @@ class Ajax::InboxController < AjaxController
     inbox = Inbox.create!(user: current_user, question_id: question.id, new: true)
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.inbox.create.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
     @response[:render] = render_to_string(partial: 'inbox/entry', locals: { i: inbox })
     inbox.update(new: false)
@@ -27,7 +27,7 @@ class Ajax::InboxController < AjaxController
 
     unless current_user == inbox.user
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.inbox.remove.fail')
+      @response[:message] = t(".error")
       return
     end
 
@@ -36,12 +36,12 @@ class Ajax::InboxController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :err
-      @response[:message] = I18n.t('messages.error')
+      @response[:message] = t("errors.base")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.inbox.remove.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -53,12 +53,12 @@ class Ajax::InboxController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :err
-      @response[:message] = I18n.t('messages.error')
+      @response[:message] = t("errors.base")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.inbox.remove_all.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -71,12 +71,12 @@ class Ajax::InboxController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :err
-      @response[:message] = I18n.t('messages.error')
+      @response[:message] = t("errors.base")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.inbox.remove_all.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/list_controller.rb
+++ b/app/controllers/ajax/list_controller.rb
@@ -4,7 +4,7 @@ class Ajax::ListController < AjaxController
 
     unless user_signed_in?
       @response[:status] = :noauth
-      @response[:message] = I18n.t('messages.noauth')
+      @response[:message] = t(".noauth")
       return
     end
 
@@ -13,7 +13,7 @@ class Ajax::ListController < AjaxController
     rescue ActionController::ParameterMissing => e
       Sentry.capture_exception(e)
       @response[:status] = :toolong
-      @response[:message] = I18n.t('messages.list.create.noname')
+      @response[:message] = t(".noname")
       return
     end
     params.require :user
@@ -24,23 +24,23 @@ class Ajax::ListController < AjaxController
     rescue ActiveRecord::RecordInvalid => e
       Sentry.capture_exception(e)
       @response[:status] = :toolong
-      @response[:message] = I18n.t('messages.list.create.toolong')
+      @response[:message] = t(".toolong")
       return
     rescue ActiveRecord::RecordNotFound => e
       Sentry.capture_exception(e)
       @response[:status] = :notfound
-      @response[:message] = I18n.t('messages.list.create.notfound')
+      @response[:message] = t(".notfound")
       return
     rescue ActiveRecord::RecordNotUnique => e
       Sentry.capture_exception(e)
       @response[:status] = :exists
-      @response[:message] = I18n.t('messages.list.create.exists')
+      @response[:message] = t(".exists")
       return
     end
 
     @response[:status] = :okay
     @response[:success] = true
-    @response[:message] = I18n.t('messages.list.create.okay')
+    @response[:message] = t(".success")
     @response[:render] = render_to_string(partial: 'modal/list/item', locals: { list: list, user: target_user })
   end
 
@@ -49,7 +49,7 @@ class Ajax::ListController < AjaxController
 
     unless user_signed_in?
       @response[:status] = :noauth
-      @response[:message] = I18n.t('messages.noauth')
+      @response[:message] = t(".noauth")
       return
     end
 
@@ -60,13 +60,13 @@ class Ajax::ListController < AjaxController
     rescue ActiveRecord::RecordNotFound => e
       Sentry.capture_exception(e)
       @response[:status] = :notfound
-      @response[:message] = I18n.t('messages.list.destroy.notfound')
+      @response[:message] = t(".notfound")
       return
     end
 
     @response[:status] = :okay
     @response[:success] = true
-    @response[:message] = I18n.t('messages.list.destroy.okay')
+    @response[:message] = t(".success")
   end
 
   def membership
@@ -74,7 +74,7 @@ class Ajax::ListController < AjaxController
 
     unless user_signed_in?
       @response[:status] = :noauth
-      @response[:message] = I18n.t('messages.noauth')
+      @response[:message] = t(".noauth")
       return
     end
 
@@ -89,7 +89,7 @@ class Ajax::ListController < AjaxController
     rescue ActiveRecord::RecordNotFound => e
       Sentry.capture_exception(e)
       @response[:status] = :notfound
-      @response[:message] = I18n.t('messages.list.membership.notfound')
+      @response[:message] = t(".notfound")
       return
     end
 
@@ -101,11 +101,11 @@ class Ajax::ListController < AjaxController
     if add
       list.add_member target_user if list.members.find_by_user_id(target_user.id).nil?
       @response[:checked] = true
-      @response[:message] = I18n.t('messages.list.membership.add')
+      @response[:message] = t(".success.add")
     else
       list.remove_member target_user unless list.members.find_by_user_id(target_user.id).nil?
       @response[:checked] = false
-      @response[:message] = I18n.t('messages.list.membership.remove')
+      @response[:message] = t(".success.remove")
     end
 
     @response[:status] = :okay

--- a/app/controllers/ajax/moderation_controller.rb
+++ b/app/controllers/ajax/moderation_controller.rb
@@ -14,13 +14,13 @@ class Ajax::ModerationController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.moderation.vote.fail')
+      @response[:message] = t(".error")
       return
     end
 
     @response[:count] = report.votes
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.moderation.vote.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -34,13 +34,13 @@ class Ajax::ModerationController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.moderation.destroy_vote.fail')
+      @response[:message] = t(".error")
       return
     end
 
     @response[:count] = report.votes
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.moderation.destroy_vote.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -55,12 +55,12 @@ class Ajax::ModerationController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.moderation.destroy_report.fail')
+      @response[:message] = t(".error")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.moderation.destroy_report.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -76,12 +76,12 @@ class Ajax::ModerationController < AjaxController
     rescue ActiveRecord::RecordInvalid => e
       Sentry.capture_exception(e)
       @response[:status] = :rec_inv
-      @response[:message] = I18n.t('messages.moderation.create_comment.rec_inv')
+      @response[:message] = t(".invalid")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.moderation.create_comment.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
     @response[:render] = render_to_string(partial: 'moderation/discussion', locals: { report: report })
     @response[:count] = report.moderation_comments.all.count
@@ -95,20 +95,20 @@ class Ajax::ModerationController < AjaxController
 
     unless current_user == comment.user
       @response[:status] = :nopriv
-      @response[:message] = I18n.t('messages.moderation.destroy_comment.nopriv')
+      @response[:message] = t(".nopriv")
       return
     end
 
     comment.destroy
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.moderation.destroy_comment.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
   def ban
     @response[:status] = :err
-    @response[:message] = I18n.t('messages.moderation.ban.error')
+    @response[:message] = t(".error")
 
     params.require :user
     params.require :ban
@@ -122,18 +122,18 @@ class Ajax::ModerationController < AjaxController
 
     if !unban && target_user.has_role?(:administrator)
       @response[:status] = :nopriv
-      @response[:message] = I18n.t('messages.moderation.ban.nopriv')
+      @response[:message] = t(".nopriv")
       return
     end
 
     if unban
       UseCase::User::Unban.call(target_user.id)
-      @response[:message] = I18n.t('messages.moderation.ban.unban')
+      @response[:message] = t(".success.unban")
       @response[:success] = true
       @response[:status]  = :okay
       return
     elsif perma
-      @response[:message] = I18n.t('messages.moderation.ban.perma')
+      @response[:message] = t(".success.permanent")
       expiry = nil
     else
       params.require :duration
@@ -142,7 +142,7 @@ class Ajax::ModerationController < AjaxController
       raise Errors::InvalidBanDuration unless %w[hours days weeks months].include? duration_unit
 
       expiry = DateTime.now + duration.public_send(duration_unit)
-      @response[:message] = I18n.t('messages.moderation.ban.temp', date: expiry.to_s)
+      @response[:message] = I18n.t(".success.temporary", date: expiry.to_s)
     end
 
     UseCase::User::Ban.call(
@@ -168,12 +168,12 @@ class Ajax::ModerationController < AjaxController
 
     target_user = User.find_by_screen_name!(params[:user])
 
-    @response[:message] = I18n.t('messages.moderation.privilege.nope')
+    @response[:message] = t(".error")
     return unless %w(moderator admin).include? params[:type].downcase
 
     unless current_user.has_role?(:administrator)
       @response[:status] = :nopriv
-      @response[:message] = I18n.t('messages.moderation.privilege.nopriv')
+      @response[:message] = t(".nopriv")
       return
     end
 
@@ -188,7 +188,7 @@ class Ajax::ModerationController < AjaxController
     end
     target_user.save!
 
-    @response[:message] = I18n.t('messages.moderation.privilege.checked', privilege: params[:type])
+    @response[:message] = t(".success", privilege: params[:type])
 
     @response[:status] = :okay
     @response[:success] = true

--- a/app/controllers/ajax/question_controller.rb
+++ b/app/controllers/ajax/question_controller.rb
@@ -10,20 +10,20 @@ class Ajax::QuestionController < AjaxController
     question = Question.find params[:question]
     if question.nil?
       @response[:status] = :not_found
-      @response[:message] = I18n.t('messages.question.destroy.not_found')
+      @response[:message] = t(".notfound")
       return
     end
 
     if not (current_user.mod? or question.user == current_user)
       @response[:status] = :not_authorized
-      @response[:message] = I18n.t('messages.question.destroy.not_authorized')
+      @response[:message] = t(".noauth")
       return
     end
 
     question.destroy!
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.question.destroy.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -44,7 +44,7 @@ class Ajax::QuestionController < AjaxController
     rescue ActiveRecord::RecordInvalid => e
       Sentry.capture_exception(e)
       @response[:status] = :rec_inv
-      @response[:message] = I18n.t('messages.question.create.rec_inv')
+      @response[:message] = t(".invalid")
       return
     end
 
@@ -64,7 +64,7 @@ class Ajax::QuestionController < AjaxController
 
       if target_user.nil?
         @response[:status] = :not_found
-        @response[:message] = I18n.t('messages.question.create.not_found')
+        @response[:message] = t(".notfound")
         question.delete
         return
       end
@@ -90,7 +90,7 @@ class Ajax::QuestionController < AjaxController
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.question.create.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/relationship_controller.rb
+++ b/app/controllers/ajax/relationship_controller.rb
@@ -16,7 +16,7 @@ class Ajax::RelationshipController < AjaxController
       type:        params[:type]
     )
     @response[:success] = true
-    @response[:message] = t("messages.#{params[:type]}.create.okay")
+    @response[:message] = t(".#{params[:type]}.success")
   rescue Errors::Base => e
     @response[:message] = t(e.locale_tag)
   ensure
@@ -30,7 +30,7 @@ class Ajax::RelationshipController < AjaxController
       type:        params[:type]
     )
     @response[:success] = true
-    @response[:message] = t("messages.#{params[:type]}.destroy.okay")
+    @response[:message] = t(".#{params[:type]}.success")
   rescue Errors::Base => e
     @response[:message] = t(e.locale_tag)
   ensure

--- a/app/controllers/ajax/report_controller.rb
+++ b/app/controllers/ajax/report_controller.rb
@@ -5,13 +5,14 @@ class Ajax::ReportController < AjaxController
 
     @response[:status] = :err
 
-    if current_user.nil?
-      @response[:message] = I18n.t('messages.report.create.login')
+    unless user_signed_in?
+      @response[:status] = :noauth
+      @response[:message] = t(".noauth")
       return
     end
 
     unless %w(answer comment question user).include? params[:type]
-      @response[:message] = I18n.t('messages.report.create.unknown')
+      @response[:message] = t(".unknown")
       return
     end
 
@@ -31,14 +32,14 @@ class Ajax::ReportController < AjaxController
       end
 
     if object.nil?
-      @response[:message] = I18n.t('messages.report.create.not_found', parameter: params[:type])
+      @response[:message] = t(".notfound", parameter: params[:type])
       return
     end
 
     current_user.report object, params[:reason]
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.report.create.okay', parameter: params[:type])
+    @response[:message] = t(".success", parameter: params[:type])
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/report_controller.rb
+++ b/app/controllers/ajax/report_controller.rb
@@ -39,7 +39,7 @@ class Ajax::ReportController < AjaxController
     current_user.report object, params[:reason]
 
     @response[:status] = :okay
-    @response[:message] = t(".success", parameter: params[:type])
+    @response[:message] = t(".success", parameter: params[:type].titleize)
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/smile_controller.rb
+++ b/app/controllers/ajax/smile_controller.rb
@@ -13,12 +13,12 @@ class Ajax::SmileController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.smile.create.fail')
+      @response[:message] = t(".error")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.smile.create.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -32,12 +32,12 @@ class Ajax::SmileController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.smile.destroy.fail')
+      @response[:message] = t(".error")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.smile.destroy.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -55,12 +55,12 @@ class Ajax::SmileController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.smile.create_comment.fail')
+      @response[:message] = t(".error")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.smile.create_comment.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 
@@ -74,12 +74,12 @@ class Ajax::SmileController < AjaxController
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :fail
-      @response[:message] = I18n.t('messages.smile.destroy_comment.fail')
+      @response[:message] = t(".error")
       return
     end
 
     @response[:status] = :okay
-    @response[:message] = I18n.t('messages.smile.destroy_comment.okay')
+    @response[:message] = t(".success")
     @response[:success] = true
   end
 end

--- a/app/controllers/ajax/subscription_controller.rb
+++ b/app/controllers/ajax/subscription_controller.rb
@@ -3,16 +3,14 @@ class Ajax::SubscriptionController < AjaxController
 
   def subscribe
     params.require :answer
-    @response[:status] = 418
-    @response[:message] = I18n.t('messages.subscription.torpedo')
+    @response[:status] = :okay
     state = Subscription.subscribe(current_user, Answer.find(params[:answer])).nil?
     @response[:success] = state == false
   end
 
   def unsubscribe
     params.require :answer
-    @response[:status] = 418
-    @response[:message] = I18n.t('messages.subscription.torpedo')
+    @response[:status] = :okay
     state = Subscription.unsubscribe(current_user, Answer.find(params[:answer])).nil?
     @response[:success] = state == false
   end

--- a/app/controllers/ajax_controller.rb
+++ b/app/controllers/ajax_controller.rb
@@ -12,7 +12,7 @@ class AjaxController < ApplicationController
 
       @response = {
         success: false,
-        message: "Something went wrong",
+        message: t("errors.base"),
         status:  :err
       }
 
@@ -25,7 +25,7 @@ class AjaxController < ApplicationController
 
     @response = {
       success: false,
-      message: "Missing parameter: #{e.key}",
+      message: t("errors.parameter_error", parameter: e.key),
       status:  :err
     }
 
@@ -37,7 +37,7 @@ class AjaxController < ApplicationController
 
     @response = {
       success: false,
-      message: "Invalid parameter",
+      message: t("errors.invalid_parameter"),
       status:  :err
     }
 
@@ -49,7 +49,7 @@ class AjaxController < ApplicationController
 
     @response = {
       success: false,
-      message: "Record not found",
+      message: t("errors.record_not_found"),
       status:  :not_found
     }
 
@@ -61,7 +61,7 @@ class AjaxController < ApplicationController
 
     @response = {
       success: false,
-      message: I18n.t("messages.parameter_error", parameter: e.param.capitalize),
+      message: t("errors.parameter_error", parameter: e.param.capitalize),
       status:  :parameter_error
     }
 

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -6,6 +6,14 @@ en:
       destroy:
         nopriv: "Cannot remove a block belonging to someone else."
         success: :ajax.relationship.destroy.block.success
+    answer:
+      create:
+        privacy: "This user does not want other users to answer their question."
+        success: "Successfully answered question."
+        error: "Question is not in your inbox."
+      destroy:
+        nopriv: "Can't delete other people's answers."
+        success: "Successfully deleted answer."
     comment:
       create:
         invalid: "Your comment is too long."

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -34,6 +34,19 @@ en:
         follow:
           success: "Successfully unfollowed user."
           error: "You are not following that user."
+    smile:
+      create:
+        success: "Successfully smiled answer."
+        error: "You have already smiled that answer."
+      create_comment:
+        success: "Successfully smiled comment."
+        error: "You have already smiled that comment."
+      destroy:
+        success: "Successfully unsmiled answer."
+        error: "You have not smiled that answer."
+      destroy_comment:
+        success: "Successfully unsmiled comment."
+        error: "You have not smiled that comment."
   announcement:
     create:
       success: "Announcement created successfully."

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -114,6 +114,12 @@ en:
         follow:
           success: "Successfully unfollowed user."
           error: "You are not following that user."
+    report:
+      create:
+        noauth: :messages.noauth
+        unknown: "You can't report this entity."
+        notfound: "Could not find %{parameter}"
+        success: "%{parameter} reported.  A moderator will decide what happens with the %{parameter}."
     smile:
       create:
         success: "Successfully smiled answer."

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -24,6 +24,24 @@ en:
         success: "Successfully deleted questions."
       remove_all_author:
         success: :ajax.inbox.remove_all.success
+    list:
+      create:
+        noauth: :messages.noauth
+        noname: "Please give that list a name."
+        toolong: "List name too long (30 characters max.)"
+        notfound: "Could not find user."
+        exists: "List already exists."
+        success: "Successfully created list."
+      destroy:
+        noauth: :messages.noauth
+        notfound: "Could not find list."
+        success: "Successfully deleted list."
+      membership:
+        noauth: :messages.noauth
+        notfound: "List not found."
+        success:
+          add: "Successfully added user to list."
+          remove: "Successfully removed user from list."
     mute_rule:
       nopriv: "Can't edit other people's rules"
       create:

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -13,6 +13,17 @@ en:
       destroy:
         nopriv: "Can't delete other people's comments."
         success: "Successfully deleted comment."
+    inbox:
+      create:
+        noauth: :messages.noauth
+        success: "Successfully added new question."
+      remove:
+        success: "Successfully deleted question."
+        error: "Question is not in your inbox."
+      remove_all:
+        success: "Successfully deleted questions."
+      remove_all_author:
+        success: :ajax.inbox.remove_all.success
     mute_rule:
       nopriv: "Can't edit other people's rules"
       create:

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -1,5 +1,11 @@
 en:
   ajax:
+    anonymous_block:
+      create:
+        success: :ajax.relationship.create.block.success
+      destroy:
+        nopriv: "Cannot remove a block belonging to someone else."
+        success: :ajax.relationship.destroy.block.success
     mute_rule:
       nopriv: "Can't edit other people's rules"
       create:
@@ -13,6 +19,21 @@ en:
         noauth: :messages.noauth
         nopriv: :ajax.mute_rule.nopriv
         success: "Rule deleted successfully."
+    relationship:
+      create:
+        block:
+          success: "Successfully blocked user."
+          error: "You are already blocking that user."
+        follow:
+          success: "Successfully followed user."
+          error: "You are already following that user."
+      destroy:
+        block:
+          success: "Successfully unblocked user."
+          error: "You are not blocking that user."
+        follow:
+          success: "Successfully unfollowed user."
+          error: "You are not following that user."
   announcement:
     create:
       success: "Announcement created successfully."

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -6,6 +6,13 @@ en:
       destroy:
         nopriv: "Cannot remove a block belonging to someone else."
         success: :ajax.relationship.destroy.block.success
+    comment:
+      create:
+        invalid: "Your comment is too long."
+        success: "Comment posted successfully."
+      destroy:
+        nopriv: "Can't delete other people's comments."
+        success: "Successfully deleted comment."
     mute_rule:
       nopriv: "Can't edit other people's rules"
       create:

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -82,6 +82,15 @@ en:
         noauth: :messages.noauth
         nopriv: :ajax.mute_rule.nopriv
         success: "Rule deleted successfully."
+    question:
+      create:
+        invalid: "Your question is too long."
+        notfound: "User not found."
+        success: "Question asked successfully."
+      destroy:
+        notfound: "Question does not exist."
+        noauth: "You are not allowed to delete this question."
+        success: "Successfully deleted question."
     relationship:
       create:
         block:

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -1,5 +1,6 @@
 en:
   ajax:
+    noauth: "You need to be logged in to perform this action."
     anonymous_block:
       create:
         success: :ajax.relationship.create.block.success
@@ -23,7 +24,7 @@ en:
         success: "Successfully deleted comment."
     inbox:
       create:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         success: "Successfully added new question."
       remove:
         success: "Successfully deleted question."
@@ -34,18 +35,18 @@ en:
         success: :ajax.inbox.remove_all.success
     list:
       create:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         noname: "Please give that list a name."
         toolong: "List name too long (30 characters max.)"
         notfound: "Could not find user."
         exists: "List already exists."
         success: "Successfully created list."
       destroy:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         notfound: "Could not find list."
         success: "Successfully deleted list."
       membership:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         notfound: "List not found."
         success:
           add: "Successfully added user to list."
@@ -80,14 +81,14 @@ en:
     mute_rule:
       nopriv: "Can't edit other people's rules"
       create:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         success: "Rule added successfully."
       update:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         nopriv: :ajax.mute_rule.nopriv
         success: "Rule updated successfully."
       destroy:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         nopriv: :ajax.mute_rule.nopriv
         success: "Rule deleted successfully."
     question:
@@ -116,7 +117,7 @@ en:
           error: "You are not following that user."
     report:
       create:
-        noauth: :messages.noauth
+        noauth: :ajax.noauth
         unknown: "You can't report this entity."
         notfound: "Could not find %{parameter}"
         success: "%{parameter} reported.  A moderator will decide what happens with the %{parameter}."

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -42,6 +42,33 @@ en:
         success:
           add: "Successfully added user to list."
           remove: "Successfully removed user from list."
+    moderation:
+      vote:
+        success: "Successfully voted on report."
+        error: "You have already voted on this report."
+      destroy_vote:
+        success: "Successfully removed vote from report."
+        error: "You have not voted on that report."
+      destroy_report:
+        success: "Successfully removed report."
+        error: :errors.base
+      create_comment:
+        invalid: "Your comment is too long."
+        success: "Comment posted successfully."
+      destroy_comment:
+        nopriv: "Can't delete other people's comments."
+        success: "Successfully deleted comment."
+      ban:
+        nopriv: "You cannot ban an administrator!"
+        success:
+          unban: "Unbanned user."
+          permanent: "Permanently banned user."
+          temporary: "Banned user until %{date}"
+        error: "Something went wrong while banning this user."
+      privilege:
+        nopriv: "You can't change the role of this user."
+        success: "Successfully adjusted this users %{privilege} role."
+        error: "Something went wrong while adjusting this role."
     mute_rule:
       nopriv: "Can't edit other people's rules"
       create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,12 +56,6 @@ en:
     error: "An error occurred."
     parameter_error: "%{parameter} is required."
     noauth: "requires authentication"
-    report:
-      create:
-        login: "login required"
-        unknown: "unknown type"
-        not_found: "Could not find %{parameter}"
-        okay: "%{parameter} reported.  A moderator will decide what happens with the %{parameter}."
     subscription:
       torpedo: "418 I'm a torpedo"
   views:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,32 +65,6 @@ en:
       destroy:
         nopriv: "can't delete other people's answers"
         okay: "Successfully deleted answer."
-    moderation:
-      vote:
-        fail: "You have already voted on this report."
-        okay: "Successfully voted on report."
-      destroy_vote:
-        fail: "You have not voted on that report."
-        okay: "Successfully removed vote from report."
-      destroy_report:
-        fail: "Something bad happened!"
-        okay: "WHERE DID IT GO??? OH NO!!!"
-      create_comment:
-        rec_inv: "Your comment is too long."
-        okay: "Comment posted successfully."
-      destroy_comment:
-        nopriv: "can't delete other people's comments"
-        okay: "Successfully deleted comment."
-      ban:
-        error: "Weird..."
-        nopriv: "You cannot ban an administrator!"
-        unban: "Unbanned user."
-        perma: "Permanently banned user."
-        temp: "Banned user until %{date}"
-      privilege:
-        nope: "nope!"
-        nopriv: "You'd better check YOUR privileges first!"
-        checked: "Successfully checked this user's %{privilege} privilege."
     question:
       destroy:
         not_found: "Question does not exist"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,20 +65,6 @@ en:
       destroy:
         nopriv: "can't delete other people's answers"
         okay: "Successfully deleted answer."
-    list:
-      create:
-        noname: "Please give that list a name."
-        toolong: "List name too long (30 characters max.)"
-        notfound: "Could not find user."
-        exists: "List already exists."
-        okay: "Successfully created list."
-      destroy:
-        notfound: "Could not find list."
-        okay: "Successfully deleted list."
-      membership:
-        notfound: "List not found."
-        add: "Successfully added user to list."
-        remove: "Successfully removed user from list."
     moderation:
       vote:
         fail: "You have already voted on this report."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,14 +79,6 @@ en:
         notfound: "List not found."
         add: "Successfully added user to list."
         remove: "Successfully removed user from list."
-    inbox:
-      create:
-        okay: "Successfully added new question."
-      remove:
-        fail: "question not in your inbox"
-        okay: "Successfully deleted question."
-      remove_all:
-        okay: "Successfully deleted questions."
     moderation:
       vote:
         fail: "You have already voted on this report."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,15 +56,6 @@ en:
     error: "An error occurred."
     parameter_error: "%{parameter} is required."
     noauth: "requires authentication"
-    answer:
-      create:
-        fail: "Question is not in your inbox."
-        privacy_stronk: "This user does not want other users to answer their question."
-        peter_dinklage: "Answer is too short."
-        okay: "Successfully answered question."
-      destroy:
-        nopriv: "can't delete other people's answers"
-        okay: "Successfully deleted answer."
     report:
       create:
         login: "login required"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,9 +53,6 @@ en:
       until: "Banned until: %{time}"
   messages:
     noscript: "Please activate JavaScript."
-    error: "An error occurred."
-    parameter_error: "%{parameter} is required."
-    noauth: "requires authentication"
   views:
     locale:
       languages: "Languages"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,13 +65,6 @@ en:
       destroy:
         nopriv: "can't delete other people's answers"
         okay: "Successfully deleted answer."
-    comment:
-      create:
-        rec_inv: "Your comment is too long."
-        okay: "Comment posted successfully."
-      destroy:
-        nopriv: "can't delete other people's comments"
-        okay: "Successfully deleted comment."
     list:
       create:
         noname: "Please give that list a name."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,8 +56,6 @@ en:
     error: "An error occurred."
     parameter_error: "%{parameter} is required."
     noauth: "requires authentication"
-    subscription:
-      torpedo: "418 I'm a torpedo"
   views:
     locale:
       languages: "Languages"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,15 +65,6 @@ en:
       destroy:
         nopriv: "can't delete other people's answers"
         okay: "Successfully deleted answer."
-    question:
-      destroy:
-        not_found: "Question does not exist"
-        not_authorized: "You are not allowed to delete this question"
-        okay: "Successfully deleted question."
-      create:
-        rec_inv: "Your question is too long."
-        not_found: "List not found"
-        okay: "Question asked successfully."
     report:
       create:
         login: "login required"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,19 +135,6 @@ en:
         unknown: "unknown type"
         not_found: "Could not find %{parameter}"
         okay: "%{parameter} reported.  A moderator will decide what happens with the %{parameter}."
-    smile:
-      create:
-        fail: "You have already smiled that answer."
-        okay: "Successfully smiled answer."
-      destroy:
-        fail: "You have not smiled that answer."
-        okay: "Successfully unsmiled answer."
-      create_comment:
-        fail: "You have already smiled that comment."
-        okay: "Successfully smiled comment."
-      destroy_comment:
-        fail: "You have not smiled that comment."
-        okay: "Successfully unsmiled comment."
     subscription:
       torpedo: "418 I'm a torpedo"
   views:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,21 +72,6 @@ en:
       destroy:
         nopriv: "can't delete other people's comments"
         okay: "Successfully deleted comment."
-    follow:
-      create:
-        fail: "You are already following that user."
-        okay: "Successfully followed user."
-      destroy:
-        fail: "You are not following that user."
-        okay: "Successfully unfollowed user."
-    block:
-      create:
-        fail: "You are already blocking that user."
-        okay: "Successfully blocked user."
-      destroy:
-        fail: "You are not blocking that user."
-        okay: "Successfully unblocked user."
-        nopriv: "Cannot remove a block belonging to someone else."
     list:
       create:
         noname: "Please give that list a name."

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -27,3 +27,9 @@ en:
     conflict: "This already exists"
 
     invalid_otp: "The code you entered was invalid."
+
+    parameter_error: "%{parameter} is required."
+
+    invalid_parameter: "Invalid parameter"
+
+    record_not_found: "Record not found"

--- a/spec/controllers/ajax/report_controller_spec.rb
+++ b/spec/controllers/ajax/report_controller_spec.rb
@@ -136,7 +136,7 @@ describe Ajax::ReportController, :ajax_controller, type: :controller do
       let(:expected_response) do
         {
           "success" => false,
-          "status" => "noauth",
+          "status" =>  "noauth",
           "message" => anything
         }
       end

--- a/spec/controllers/ajax/report_controller_spec.rb
+++ b/spec/controllers/ajax/report_controller_spec.rb
@@ -136,7 +136,7 @@ describe Ajax::ReportController, :ajax_controller, type: :controller do
       let(:expected_response) do
         {
           "success" => false,
-          "status" => "err",
+          "status" => "noauth",
           "message" => anything
         }
       end

--- a/spec/controllers/ajax/subscription_controller_spec.rb
+++ b/spec/controllers/ajax/subscription_controller_spec.rb
@@ -25,7 +25,7 @@ describe Ajax::SubscriptionController, :ajax_controller, type: :controller do
         let(:expected_response) do
           {
             "success" => true,
-            "status" => 418,
+            "status" => "okay",
             "message" => anything
           }
         end
@@ -96,7 +96,7 @@ describe Ajax::SubscriptionController, :ajax_controller, type: :controller do
         let(:expected_response) do
           {
             "success" => true,
-            "status" => 418,
+            "status" => "okay",
             "message" => anything
           }
         end
@@ -116,7 +116,7 @@ describe Ajax::SubscriptionController, :ajax_controller, type: :controller do
           let(:expected_response) do
             {
               "success" => false,
-              "status" => 418,
+              "status" => "okay",
               "message" => anything
             }
           end

--- a/spec/controllers/ajax/subscription_controller_spec.rb
+++ b/spec/controllers/ajax/subscription_controller_spec.rb
@@ -25,7 +25,7 @@ describe Ajax::SubscriptionController, :ajax_controller, type: :controller do
         let(:expected_response) do
           {
             "success" => true,
-            "status" => "okay",
+            "status" =>  "okay",
             "message" => anything
           }
         end
@@ -96,7 +96,7 @@ describe Ajax::SubscriptionController, :ajax_controller, type: :controller do
         let(:expected_response) do
           {
             "success" => true,
-            "status" => "okay",
+            "status" =>  "okay",
             "message" => anything
           }
         end
@@ -116,7 +116,7 @@ describe Ajax::SubscriptionController, :ajax_controller, type: :controller do
           let(:expected_response) do
             {
               "success" => false,
-              "status" => "okay",
+              "status" =>  "okay",
               "message" => anything
             }
           end


### PR DESCRIPTION
Mostly just moves locales into the new `controllers.en.yml` file with proper namespacing, plus some adjustments here and there.

There's a lot of improvements to be made here, but these come from logic/validation/guarding and probably will get rid of a bunch of the locales made here, this is just an initial step of moving all the things into proper places.

**Testing:**
* Make sure all AJAX actions return proper messages

![b3876017-7b6a-45b9-88e0-6db0053de207_1 9f94b6df6df1fe784c665df21a5a619f](https://user-images.githubusercontent.com/1774242/177538410-e0b3e228-2125-4e47-b7d6-21001eb827bf.jpeg)

