### PR TITLE
Always denotify when deleting reactions

### DIFF
--- a/app/models/appendable/reaction.rb
+++ b/app/models/appendable/reaction.rb
@@ -9,7 +9,7 @@ class Appendable::Reaction < Appendable
   end
 
   before_destroy do
-    Notification.denotify parent.user, self unless parent.user == user
+    Notification.denotify parent.user, self
     user.decrement! :smiled_count
     parent.decrement! :smile_count
   end


### PR DESCRIPTION
This caused 500s for users with notifications for deleted reactions.