### PR TITLE
Fix notifications being orphaned on parent being deleted

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -31,7 +31,7 @@ class Notification < ApplicationRecord
       notif_type = target.notification_type
       return nil unless notif_type
 
-      notif = notif_type.find_by(recipient: recipient, target: target)
+      notif = Notification.find_by(recipient: recipient, target: target)
       notif.destroy unless notif.nil?
     end
 
@@ -39,7 +39,6 @@ class Notification < ApplicationRecord
 
       def make_notification(recipient, target, notification_type)
         n = notification_type.new(target: target,
-                                  target_type: target.class.name,  # To ensure we don't get a type of 'Appenddable'
                                   recipient: recipient,
                                   new: true)
         n.save!

--- a/app/views/navigation/main/_notifications.haml
+++ b/app/views/navigation/main/_notifications.haml
@@ -19,7 +19,7 @@
     - else
       - notifications.each do |notification|
         .dropdown-item
-          = render "notifications/type/#{notification.target.type.downcase.split('::').last}", notification: notification
+          = render "notifications/type/#{notification.target.class.name.downcase.split('::').last}", notification: notification
 
       %a.dropdown-item.text-center{ href: notifications_path }
         %i.fa.fa-fw.fa-chevron-right

--- a/app/views/navigation/main/_notifications.haml
+++ b/app/views/navigation/main/_notifications.haml
@@ -19,7 +19,7 @@
     - else
       - notifications.each do |notification|
         .dropdown-item
-          = render "notifications/type/#{notification.target_type.downcase.split('::').last}", notification: notification
+          = render "notifications/type/#{notification.target.type.downcase.split('::').last}", notification: notification
 
       %a.dropdown-item.text-center{ href: notifications_path }
         %i.fa.fa-fw.fa-chevron-right

--- a/app/views/notifications/index.haml
+++ b/app/views/notifications/index.haml
@@ -13,7 +13,7 @@
       - @notifications.each do |notification|
         %li.list-group-item
           .media
-            = render "notifications/type/#{notification.target_type.downcase.split('::').last}", notification: notification
+            = render "notifications/type/#{notification.target.class.name.downcase.split('::').last}", notification: notification
 
   - unless @notifications.count.zero?
     = render 'shared/cursored_pagination_dummy', more_data_available: @more_data_available, last_id: @notifications_last_id, permitted_params: %i[type]

--- a/db/migrate/20220708203722_correct_notification_target_types.rb
+++ b/db/migrate/20220708203722_correct_notification_target_types.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CorrectNotificationTargetTypes < ActiveRecord::Migration[6.1]
+  def up
+    execute "UPDATE notifications SET target_type = 'Appendable' WHERE target_type = 'Appendable::Reaction'"
+
+    execute "UPDATE notifications SET target_type = 'Relationship' WHERE target_type = 'Relationships::Follow'"
+  end
+end

--- a/db/migrate/20220708204200_remove_orphaned_notifications.rb
+++ b/db/migrate/20220708204200_remove_orphaned_notifications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveOrphanedNotifications < ActiveRecord::Migration[6.1]
+  def up
+    execute "DELETE FROM notifications WHERE target_type = 'Appendable' AND target_id NOT IN (SELECT id FROM appendables)"
+
+    execute "DELETE FROM notifications WHERE target_type = 'Relationship' AND target_id NOT IN (SELECT id FROM relationships)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_08_203722) do
+ActiveRecord::Schema.define(version: 2022_07_08_204200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_174816) do
+ActiveRecord::Schema.define(version: 2022_07_08_203722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Answer, type: :model do
+  describe "associations" do
+    it { should belong_to(:user) }
+    it { should belong_to(:question) }
+    it { should have_many(:comments).dependent(:destroy) }
+    it { should have_many(:smiles).dependent(:destroy) }
+  end
+
+  describe "after_create" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:question_author) { FactoryBot.create(:user) }
+    let(:question) { FactoryBot.create(:question, user: question_author, author_is_anonymous: false) }
+
+    before do
+      subject.content = "Answer text"
+      subject.user = user
+      subject.question = question
+    end
+
+    context "user has the question in their inbox" do
+      before do
+        Inbox.create(user: user, question: question, new: true)
+      end
+
+      it "should remove the question from the user's inbox" do
+        expect { subject.save }.to change { user.inboxes.count }.by(-1)
+      end
+    end
+
+    it "should notify the question's author" do
+      expect { subject.save }.to change { question_author.notifications.count }.by(1)
+    end
+
+    it "should subscribe the answer's author to notifications for this answer" do
+      expect { subject.save }.to change { user.subscriptions.count }.by(1)
+      expect(user.subscriptions.first.answer).to eq(subject)
+    end
+
+    it "should subscribe the question's author to notifications for this answer" do
+      expect { subject.save }.to change { question_author.subscriptions.count }.by(1)
+    end
+
+    it "should increment the user's answered_count" do
+      expect { subject.save }.to change { user.answered_count }.by(1)
+    end
+
+    it "should increment the question's answer_count" do
+      expect { subject.save }.to change { question.answer_count }.by(1)
+    end
+  end
+
+  describe "before_destroy" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:question_author) { FactoryBot.create(:user) }
+    let(:question) { FactoryBot.create(:question, user: question_author, author_is_anonymous: false) }
+
+    before do
+      subject.content = "Answer text"
+      subject.user = user
+      subject.question = question
+      subject.save
+    end
+
+    context "question author has a notification for the answer" do
+      before do
+        Notification.notify(question_author, subject)
+      end
+
+      it "should remove the answered notification from the question's author" do
+        expect { subject.destroy }.to change { question_author.notifications.count }.by(-1)
+      end
+    end
+
+    it "should unsubscribe the answer's author from notifications for this answer" do
+      expect { subject.destroy }.to change { user.subscriptions.count }.by(-1)
+    end
+
+    it "should unsubscribe the question's author from notifications for this answer" do
+      expect { subject.destroy }.to change { question_author.subscriptions.count }.by(-1)
+    end
+
+    it "should decrement the user's answered_count" do
+      expect { subject.destroy }.to change { user.answered_count }.by(-1)
+    end
+
+    it "should decrement the question's answer_count" do
+      expect { subject.destroy }.to change { question.answer_count }.by(-1)
+    end
+  end
+end

--- a/spec/models/appendable/reaction_spec.rb
+++ b/spec/models/appendable/reaction_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Appendable::Reaction do
+  let(:user) { FactoryBot.create(:user) }
+  let(:owner) { FactoryBot.create(:user) }
+  let(:parent) { FactoryBot.create(:answer, user: owner) }
+
+  before do
+    subject.content = "🙂"
+    subject.parent = parent
+    subject.user = user
+  end
+
+  describe "associations" do
+    it { should belong_to(:user) }
+    it { should belong_to(:parent) }
+  end
+
+  describe "after_create" do
+    context "owner is subscribed to the parent" do
+      before do
+        Subscription.subscribe(owner, parent)
+      end
+
+      it "should notify the parent's author" do
+        expect { subject.save }.to change { owner.notifications.count }.by(1)
+      end
+    end
+
+    it "should increment the user's smiled count" do
+      expect { subject.save }.to change { user.smiled_count }.by(1)
+    end
+
+    it "should increment the parent's smiled count" do
+      expect { subject.save }.to change { parent.smile_count }.by(1)
+    end
+  end
+
+  describe "before_destroy" do
+    context "owner has a notification for this reaction" do
+      before do
+        subject.save
+        Notification.notify(owner, subject)
+      end
+
+      it "should denotify the parent's author" do
+        expect { subject.destroy }.to change { owner.notifications.count }.by(-1)
+      end
+    end
+
+    it "should reduce the user's smiled count" do
+      expect { subject.destroy }.to change { user.smiled_count }.by(-1)
+    end
+
+    it "should reduce the parent's smiled count" do
+      expect { subject.destroy }.to change { parent.smile_count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
For some reason when adding appendables, I didn't think that I could use `notification.target.type` and did something really hacky instead. Turns out this breaks our `Notification#denotify` method

[You Fools! You've messed with the natural order!](https://www.youtube.com/watch?v=sRLlYXKPMUM)