### PR TITLE
Prevent text in links from being double-escaped

### DIFF
--- a/app/services/shared_markers.rb
+++ b/app/services/shared_markers.rb
@@ -19,7 +19,8 @@ module SharedMarkers
                               })
     end
 
-    content_tag(:a, text.nil? ? link : text, options)
+    # Marking the text content as HTML safe as <tt>content_tag</tt> already escapes it for us
+    content_tag(:a, text.nil? ? link : text.html_safe, options)
   rescue
     link
   end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -22,6 +22,15 @@ describe MarkdownHelper, type: :helper do
     it "should transform mentions into links" do
       expect(markdown("@jake_weary")).to eq('<p><a href="/jake_weary">@jake_weary</a></p>')
     end
+
+    it "should escape text in links" do
+      expect(markdown("[It's a link](https://example.com)")).to eq('<p><a href="/linkfilter?url=https%3A%2F%2Fexample.com" target="_blank" rel="nofollow">It\'s a link</a></p>')
+      expect(markdown("[It's >a link](https://example.com)")).to eq('<p><a href="/linkfilter?url=https%3A%2F%2Fexample.com" target="_blank" rel="nofollow">It\'s &gt;a link</a></p>')
+    end
+
+    it "should escape HTML tags" do
+      expect(markdown("I'm <h1>a test</h1>")).to eq("<p>I'm &lt;h1&gt;a test&lt;/h1&gt;</p>")
+    end
   end
 
   describe "#strip_markdown" do


### PR DESCRIPTION
Closes #370