### PR TITLE
Fix comment notifications displaying escaped HTML

### DIFF
--- a/app/views/notifications/type/_comment.haml
+++ b/app/views/notifications/type/_comment.haml
@@ -17,7 +17,7 @@
       - else
         = t(".heading_html",
               user: user_screen_name(notification.target.user),
-              answer: link_to(t(".other.link_text", user: user_screen_name(notification.target.answer.user)), show_user_answer_path(username: notification.target.user.screen_name, id: notification.target.answer.id)),
+              answer: link_to(t(".other.link_text_html", user: user_screen_name(notification.target.answer.user)), show_user_answer_path(username: notification.target.user.screen_name, id: notification.target.answer.id)),
               time: time_tooltip(notification.target))
     .list-group
       .list-group-item

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -124,7 +124,7 @@ en:
         passive:
           link_text: "their answer"
         other:
-          link_text: "%{user}'s answer"
+          link_text_html: "%{user}'s answer"
       reaction:
         heading_html: "%{user} smiled %{type} %{time} ago"
         answer:


### PR DESCRIPTION
Simply missed out suffixing the locales with user links with `_html`, fixes #520 

![image](https://user-images.githubusercontent.com/1774242/179370697-6bff04d0-cfa7-435b-8c07-18b3fea64d62.png)
