### PR TITLE
add rake task for easier version bumping

### DIFF
--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+namespace :version do
+  desc "Bump the version"
+  task bump: :environment do
+    puts "Current version: #{Retrospring::Version}"
+    current_ymd = %i[year month day].map { Retrospring::Version.public_send(_1) }
+
+    now = Time.now.utc
+    today_ymd = %i[year month day].map { now.public_send(_1) }
+
+    version_path = Rails.root.join("lib/version.rb")
+    version_contents = File.read(version_path)
+
+    patch_contents = lambda do |key, val|
+      version_contents.sub!(/def #{key} = .+/) { "def #{key} = #{val}" }
+    end
+
+    if current_ymd == today_ymd
+      # bump the patch version
+      patch_contents[:patch, Retrospring::Version.patch + 1]
+    else
+      # set year/month/day to today, and reset patch to 0
+      %i[year month day].each { patch_contents[_1, now.public_send(_1)] }
+      patch_contents[:patch, 0]
+    end
+
+    # write the file
+    File.write(version_path, version_contents)
+
+    # reload the version file
+    load version_path
+    puts "New version: #{Retrospring::Version}"
+  end
+
+  desc "Commit and tag a new release"
+  task commit: :environment do
+    version_path = Rails.root.join("lib/version.rb")
+
+    puts "Committing version"
+    sh %(git commit -m 'Bump version to #{Retrospring::Version}' -- #{version_path.to_s.inspect})
+
+    puts "Tagging new release"
+    sh %(git tag -a -m 'Bump version to #{Retrospring::Version}' #{Retrospring::Version})
+  end
+
+  desc "Update the version (bump + commit)"
+  task update: %i[bump commit]
+end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -13,36 +13,20 @@ module Retrospring
   module Version
     module_function
 
-    def year
-      2022
-    end
+    def year = 2022
 
-    def month
-      7
-    end
+    def month = 7
 
-    def day
-      23
-    end
+    def day = 23
 
-    def patch
-      0
-    end
+    def patch = 0
 
-    def suffix
-      ""
-    end
+    def suffix = ""
 
-    def minor
-      [month.to_s.rjust(2, "0"), day.to_s.rjust(2, "0")].join
-    end
+    def minor = [month.to_s.rjust(2, "0"), day.to_s.rjust(2, "0")].join
 
-    def to_a
-      [year.to_s, minor, patch.to_s]
-    end
+    def to_a = [year.to_s, minor, patch.to_s]
 
-    def to_s
-      [to_a.join("."), suffix].join
-    end
+    def to_s = [to_a.join("."), suffix].join
   end
 end


### PR DESCRIPTION
Just use `rake version:update` for bumping and creating the commit + tag.

example output:

```
Current version: 2022.0723.0
New version: 2022.0723.1
Committing version
git commit -m 'Bump version to 2022.0723.1' -- "/Users/foxy/src/Retrospring/retrospring/lib/version.rb"
[winver.exe c25682b3] Bump version to 2022.0723.1
 1 file changed, 1 insertion(+), 1 deletion(-)
Tagging new release
git tag -a -m 'Bump version to 2022.0723.1' 2022.0723.1
```