### PR TITLE
Improvements and bugfixes for questions

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -54,7 +54,7 @@ class UserController < ApplicationController
   def questions
     @title = 'Questions'
     @user = User.where('LOWER(screen_name) = ?', params[:username].downcase).includes(:profile).first!
-    @questions = @user.cursored_questions(author_is_anonymous: false, last_id: params[:last_id])
+    @questions = @user.cursored_questions(author_is_anonymous: false, direct: false, last_id: params[:last_id])
     @questions_last_id = @questions.map(&:id).min
     @more_data_available = !@user.cursored_questions(author_is_anonymous: false, last_id: @questions_last_id, size: 1).count.zero?
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -17,7 +17,7 @@ class Question < ApplicationRecord
     end
 
     # rubocop:disable Rails/SkipsModelValidations
-    user&.decrement! :asked_count unless author_is_anonymous
+    user&.decrement! :asked_count unless author_is_anonymous || direct
     # rubocop:enable Rails/SkipsModelValidations
   end
 

--- a/app/models/user/question_methods.rb
+++ b/app/models/user/question_methods.rb
@@ -5,9 +5,9 @@ module User::QuestionMethods
 
   define_cursor_paginator :cursored_questions, :ordered_questions
 
-  def ordered_questions(author_is_anonymous: nil)
+  def ordered_questions(author_is_anonymous: nil, direct: nil)
     questions
-      .where({ author_is_anonymous: author_is_anonymous }.compact)
+      .where({ author_is_anonymous: author_is_anonymous, direct: direct }.compact)
       .order(:created_at)
       .reverse_order
   end

--- a/app/models/user/question_methods.rb
+++ b/app/models/user/question_methods.rb
@@ -7,7 +7,7 @@ module User::QuestionMethods
 
   def ordered_questions(author_is_anonymous: nil, direct: nil)
     questions
-      .where({ author_is_anonymous: author_is_anonymous, direct: direct }.compact)
+      .where({ author_is_anonymous:, direct: }.compact)
       .order(:created_at)
       .reverse_order
   end

--- a/app/views/question/_question.haml
+++ b/app/views/question/_question.haml
@@ -25,6 +25,10 @@
                       %a.dropdown-item{ href: '#', tabindex: -1, data: { action: 'ab-question-report', q_id: question.id } }
                         %i.fa.fa-exclamation-triangle
                         = t 'views.actions.report'
+                    - if current_user.has_role? :administrator
+                      %a.dropdown-item{ href: rails_admin_path_for_resource(question) }
+                        %i.fa.fa-gears
+                        = t("voc.view_in_rails_admin")
           %h6.text-muted.media-heading.answerbox__question-user
             - identifier = question.author_is_anonymous ? question.author_identifier : nil
             - if hidden

--- a/app/views/shared/_question.haml
+++ b/app/views/shared/_question.haml
@@ -21,6 +21,10 @@
                   %a.dropdown-item{ href: '#', tabindex: -1, data: { action: 'ab-question-report', q_id: q.id } }
                     %i.fa.fa-exclamation-triangle
                     = t 'views.actions.report'
+                - if current_user.has_role? :administrator
+                  %a.dropdown-item{ href: rails_admin_path_for_resource(q) }
+                    %i.fa.fa-gears
+                    = t("voc.view_in_rails_admin")
         %h6.media-heading.text-muted.answerbox__question-user
           = raw t('views.answerbox.asked', user: user_screen_name(q.user), time: time_tooltip(q))
           - if q.answer_count > 1

--- a/app/views/shared/_question.haml
+++ b/app/views/shared/_question.haml
@@ -31,5 +31,5 @@
             ·
             %a{ href: question_path(q.user.screen_name, q.id) }
               = pluralize(q.answer_count, t('views.general.answer'))
-        %p.answerbox__question-text
-          = q.content
+        .answerbox__question-text
+          = question_markdown q.content

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -20,7 +20,8 @@ module UseCase
           content:             content,
           author_is_anonymous: anonymous,
           author_identifier:   author_identifier,
-          user:                source_user_id.nil? ? nil : source_user
+          user:                source_user_id.nil? ? nil : source_user,
+          direct:              true
         )
 
         return if filtered?(question)

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -11,6 +11,7 @@ module UseCase
       option :content, type: Types::Coercible::String
       option :anonymous, type: Types::Params::Bool, default: proc { false }
       option :author_identifier, type: Types::Coercible::String | Types::Nil
+      option :direct, type: Types::Params::Bool, default: proc { true }
 
       def call
         check_anonymous_rules
@@ -21,7 +22,7 @@ module UseCase
           author_is_anonymous: anonymous,
           author_identifier:   author_identifier,
           user:                source_user_id.nil? ? nil : source_user,
-          direct:              true
+          direct:              direct
         )
 
         return if filtered?(question)
@@ -56,7 +57,7 @@ module UseCase
       end
 
       def increment_asked_count
-        unless source_user_id && !anonymous
+        unless source_user_id && !anonymous && !direct
           # Only increment the asked count of the source user if the question
           # is not anonymous, and we actually have a source user
           return

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -59,7 +59,7 @@ module UseCase
       def increment_asked_count
         unless source_user_id && !anonymous && !direct
           # Only increment the asked count of the source user if the question
-          # is not anonymous, and we actually have a source user
+          # is not anonymous, and is not direct, and we actually have a source user
           return
         end
 

--- a/lib/use_case/question/create_followers.rb
+++ b/lib/use_case/question/create_followers.rb
@@ -14,7 +14,8 @@ module UseCase
           content:             content,
           author_is_anonymous: false,
           author_identifier:   author_identifier,
-          user:                source_user
+          user:                source_user,
+          direct:              false
         )
 
         increment_asked_count

--- a/spec/lib/use_case/question/create_spec.rb
+++ b/spec/lib/use_case/question/create_spec.rb
@@ -22,6 +22,7 @@ describe UseCase::Question::Create do
       expect(question.content).to eq(content)
       expect(question.author_is_anonymous).to eq(anonymous)
       expect(question.author_identifier).to eq(author_identifier)
+      expect(question.direct).to eq(true)
 
       if should_send_to_inbox
         expect(target_user.inboxes.first.question_id).to eq(question.id)


### PR DESCRIPTION
That PR title feels like a mobile app changelog.

**Changes:**
* **Bug fix:** Sets `direct` on direct questions again
  * **Side effect:** New direct questions don't show `1 answer` anymore
* Questions using the shared question partial actually get rendered using Markdown now
* Questions get Rails Admin links
* `direct` questions are not listed on user profiles anymore (on the `/questions` page)

Extended the UseCase tests to check for `direct` being set now.