### PR TITLE
rails_admin: group models together and add nice icons

### DIFF
--- a/.github/workflows/retrospring.yml
+++ b/.github/workflows/retrospring.yml
@@ -83,6 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt update && sudo apt-get install -y libpq-dev libxml2-dev libxslt1-dev libmagickwand-dev imagemagick libidn11-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -51,4 +51,73 @@ RailsAdmin.config do |config|
     User
     UserBan
   ]
+
+  # set up icons for some models
+  {
+    "AnonymousBlock"        => "user-secret",
+    "Answer"                => "exclamation",
+    "Appendable"            => "paperclip",
+    "Appendable::Reaction"  => "smile",
+    "Comment"               => "comment",
+    "Inbox"                 => "inbox",
+    "List"                  => "list",
+    "ListMember"            => "users",
+    "MuteRule"              => "volume-mute",
+    "Notification"          => "bell",
+    "Profile"               => "id-card",
+    "Question"              => "question",
+    "Relationship"          => "people-arrows",
+    "Relationships::Block"  => "user-slash",
+    "Relationships::Follow" => "user-friends",
+    "Report"                => "exclamation-triangle",
+    "Service"               => "network-wired",
+    "Services::Twitter"     => "dumpster-fire",
+    "Theme"                 => "paint-brush",
+    "User"                  => "user",
+    "UserBan"               => "user-lock"
+  }.each do |model, icon|
+    config.model model do
+      navigation_icon "fa fa-fw fa-#{icon} me-1"
+    end
+  end
+
+  # set up custom parents for certain models to group them nicely together
+  {
+    "AnonymousBlock" => User,
+    "Inbox"          => User,
+    "List"           => User,
+    "MuteRule"       => User,
+    "Notification"   => User,
+    "Profile"        => User,
+    "Relationship"   => User,
+    "Service"        => User,
+    "Theme"          => User,
+
+    "ListMember"     => List
+  }.each do |model, parent_model|
+    config.model model do
+      parent parent_model
+    end
+  end
+
+  # create groups inside nav tree
+  {
+    "User content" => %w[
+      Answer
+      Appendable
+      Comment
+      Question
+      User
+    ],
+    "Global"       => %w[
+      Report
+      UserBan
+    ]
+  }.each do |label, models|
+    models.each do |model|
+      config.model model do
+        navigation_label label
+      end
+    end
+  end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -3,8 +3,8 @@
 # workaround to get pagination right
 RailsAdmin.config do |config|
   config.asset_source = :webpacker
-  config.main_app_name = ['justask', 'Kontrollzentrum']
-  config.parent_controller = '::ApplicationController'
+  config.main_app_name = %w[justask Kontrollzentrum]
+  config.parent_controller = "::ApplicationController"
 
   ## == Authentication ==
   config.authenticate_with do


### PR DESCRIPTION
<img width="277" alt="Screenshot 2022-07-27 at 21 09 59" src="https://user-images.githubusercontent.com/1809170/181352989-22c50490-6a3d-4db6-ba1b-9ba5005ccd75.png" align="left">

this PR basically changes the rails admin initialiser so that...

- models now have an icon next to them
- some models are now have the User or List model as parent where it makes sense
- models containing (public-facing) user-created content are separate from reports and bans

grouping and iconing TBD, but this ⬅️ is what it looks like :-) 