### PR TITLE
Use notification types instead of target types to clear them

### DIFF
--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -4,17 +4,13 @@ class AnswerController < ApplicationController
     @display_all = true
 
     if user_signed_in?
-      notif = Notification.where(target_type: "Answer", target_id: @answer.id, recipient_id: current_user.id, new: true).first
-      unless notif.nil?
-        notif.new = false
-        notif.save
-      end
-      notif = Notification.where(target_type: "Comment", target_id: @answer.comments.pluck(:id), recipient_id: current_user.id, new: true)
+      notif = Notification.where(type: "Notification::QuestionAnswered", target_id: @answer.id, recipient_id: current_user.id, new: true).first
+      notif.update(new: false) unless notif.nil?
+      notif = Notification.where(type: "Notification::Commented", target_id: @answer.comments.pluck(:id), recipient_id: current_user.id, new: true)
       notif.update_all(new: false) unless notif.empty?
-      notif = Notification.where(target_type: "Smile", target_id: @answer.smiles.pluck(:id), recipient_id: current_user.id, new: true)
+      notif = Notification.where(type: "Notification::Smiled", target_id: @answer.smiles.pluck(:id), recipient_id: current_user.id, new: true)
       notif.update_all(new: false) unless notif.empty?
-      # @answer.comments.smiles throws
-      notif = Notification.where(target_type: "CommentSmile", target_id: @answer.comment_smiles.pluck(:id), recipient_id: current_user.id, new: true)
+      notif = Notification.where(type: "Notification::CommentSmiled", target_id: @answer.comment_smiles.pluck(:id), recipient_id: current_user.id, new: true)
       notif.update_all(new: false) unless notif.empty?
     end
   end

--- a/app/controllers/answer_controller.rb
+++ b/app/controllers/answer_controller.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 class AnswerController < ApplicationController
   def show
-    @answer = Answer.includes(comments: [:user, :smiles], question: [:user], smiles: [:user]).find(params[:id])
+    @answer = Answer.includes(comments: %i[user smiles], question: [:user], smiles: [:user]).find(params[:id])
     @display_all = true
 
     if user_signed_in?
       notif = Notification.where(type: "Notification::QuestionAnswered", target_id: @answer.id, recipient_id: current_user.id, new: true).first
-      notif.update(new: false) unless notif.nil?
+      notif&.update(new: false)
       notif = Notification.where(type: "Notification::Commented", target_id: @answer.comments.pluck(:id), recipient_id: current_user.id, new: true)
       notif.update_all(new: false) unless notif.empty?
       notif = Notification.where(type: "Notification::Smiled", target_id: @answer.smiles.pluck(:id), recipient_id: current_user.id, new: true)


### PR DESCRIPTION
`target_type` is just `Appendable` so we'll have fun once comments turn into appendables as well, so we should use `type` instead.