### PR TITLE
List direct questions for current users or mods

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -63,4 +63,8 @@ class UserController < ApplicationController
       format.js { render layout: false }
     end
   end
+
+  private
+
+  def belongs_to_current_user? = @user == current_user
 end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -54,9 +54,9 @@ class UserController < ApplicationController
   def questions
     @title = 'Questions'
     @user = User.where('LOWER(screen_name) = ?', params[:username].downcase).includes(:profile).first!
-    @questions = @user.cursored_questions(author_is_anonymous: false, direct: false, last_id: params[:last_id])
+    @questions = @user.cursored_questions(author_is_anonymous: false, direct: belongs_to_current_user? || moderation_view?, last_id: params[:last_id])
     @questions_last_id = @questions.map(&:id).min
-    @more_data_available = !@user.cursored_questions(author_is_anonymous: false, last_id: @questions_last_id, size: 1).count.zero?
+    @more_data_available = !@user.cursored_questions(author_is_anonymous: false, direct: belongs_to_current_user? || moderation_view?, last_id: @questions_last_id, size: 1).count.zero?
 
     respond_to do |format|
       format.html

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -21,6 +21,10 @@ module UserHelper
     current_user&.mod? && session[:moderation_view] == true
   end
 
+  def belongs_to_current_user?
+    @user == current_user
+  end
+
   private
 
   def profile_link(user)

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -21,10 +21,6 @@ module UserHelper
     current_user&.mod? && session[:moderation_view] == true
   end
 
-  def belongs_to_current_user?
-    @user == current_user
-  end
-
   private
 
   def profile_link(user)

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -18,7 +18,7 @@ module UserHelper
   end
 
   def moderation_view?
-    current_user&.mod? && session[:moderation_view] == true
+    !!(current_user&.mod? && session[:moderation_view] == true)
   end
 
   private

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -3,9 +3,11 @@
 require "rails_helper"
 
 describe UserController, type: :controller do
-  let(:user) { FactoryBot.create :user,
-                                 otp_module: :disabled,
-                                 otp_secret_key: 'EJFNIJPYXXTCQSRTQY6AG7XQLAT2IDG5H7NGLJE3'}
+  let(:user) do
+    FactoryBot.create :user,
+                      otp_module:     :disabled,
+                      otp_secret_key: "EJFNIJPYXXTCQSRTQY6AG7XQLAT2IDG5H7NGLJE3"
+  end
 
   describe "#show" do
     subject { get :show, params: { username: user.screen_name } }
@@ -50,7 +52,7 @@ describe UserController, type: :controller do
   end
 
   describe "#questions" do
-    let!(:question) { FactoryBot.create(:question, user: user, direct: true, author_is_anonymous: false) }
+    let!(:question) { FactoryBot.create(:question, user:, direct: true, author_is_anonymous: false) }
     subject { get :questions, params: { username: user.screen_name } }
 
     it "renders the user/questions template" do

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -61,7 +61,7 @@ describe UserController, type: :controller do
       expect(response).to render_template("user/questions")
     end
 
-    context "current user signed in" do
+    context "when the current user is the question author" do
       before do
         sign_in user
       end
@@ -72,7 +72,7 @@ describe UserController, type: :controller do
       end
     end
 
-    context "user signed in" do
+    context "when the current user is someone else" do
       let(:another_user) { FactoryBot.create :user }
 
       before do
@@ -85,7 +85,7 @@ describe UserController, type: :controller do
       end
     end
 
-    context "moderator unmasked" do
+    context "when a moderator uses unmask" do
       let(:another_user) { FactoryBot.create :user, roles: ["moderator"] }
 
       before do
@@ -99,7 +99,7 @@ describe UserController, type: :controller do
       end
     end
 
-    context "user not signed in" do
+    context "when user is not signed in" do
       it "contains no questions" do
         subject
         expect(assigns(:questions).size).to eq(0)

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     user { nil }
     content { Faker::Lorem.sentence }
     author_is_anonymous { true }
+    direct { true }
   end
 end

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -149,31 +149,4 @@ describe UserHelper, type: :helper do
       end
     end
   end
-
-  describe "#belongs_to_current_user?" do
-    context "user is logged in" do
-      let(:user) { FactoryBot.create(:user) }
-
-      before do
-        sign_in user
-        @user = user
-      end
-
-      it "returns the correct value" do
-        expect(helper.belongs_to_current_user?).to eq(true)
-      end
-    end
-
-    context "user is not logged in" do
-      let(:user) { FactoryBot.create(:user) }
-
-      before do
-        @user = user
-      end
-
-      it "returns the correct value" do
-        expect(helper.belongs_to_current_user?).to eq(false)
-      end
-    end
-  end
 end

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -149,4 +149,31 @@ describe UserHelper, type: :helper do
       end
     end
   end
+
+  describe "#belongs_to_current_user?" do
+    context "user is logged in" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        sign_in user
+        @user = user
+      end
+
+      it "returns the correct value" do
+        expect(helper.belongs_to_current_user?).to eq(true)
+      end
+    end
+
+    context "user is not logged in" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        @user = user
+      end
+
+      it "returns the correct value" do
+        expect(helper.belongs_to_current_user?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instead of completely removing direct questions from user pages, this now allows moderators (in unmask mode) and users that own the current page to view their direct questions.