### PR TITLE
answerbox: use ActiveSupport's String#truncate

### DIFF
--- a/app/views/application/_answerbox.haml
+++ b/app/views/application/_answerbox.haml
@@ -5,9 +5,8 @@
   .card-body
     - if display_all.nil?
       .answerbox__answer-text
-        = markdown a.content[0..640]
+        = markdown a.content.truncate(640, omission: " [...]", separator: /\s/)
         - if a.content.length > 640
-          [...]
           %p
             %a.btn.btn-primary{ href: answer_path(a.user.screen_name, a.id) }
               = t(".read")


### PR DESCRIPTION
[ActiveSupport's `#truncate` does a bit more than just cutting off a string](https://github.com/rails/rails/blob/2f9c84a604b3288504196e23c95348221a298b35/activesupport/lib/active_support/core_ext/string/filters.rb#L48).  there's also a [view helper for truncate](https://github.com/rails/rails/blob/2f9c84a604b3288504196e23c95348221a298b35/actionview/lib/action_view/helpers/text_helper.rb#L98), but I couldn't get that to work nicely with the "read more" button and the markdown thing.  

## before

<img width="845" alt="Screenshot 2022-08-19 at 16 36 43" src="https://user-images.githubusercontent.com/1809170/185643192-905fd9dc-07b3-4d0d-8c7e-2ed1028a03e8.png">

## after

<img width="856" alt="Screenshot 2022-08-19 at 16 36 16" src="https://user-images.githubusercontent.com/1809170/185643217-43f114af-1b2a-4208-b0c5-851cb9df1efe.png">

