### PR TITLE
Fix "other" comment notification case not linking to answer

### DIFF
--- a/app/views/notifications/type/_comment.haml
+++ b/app/views/notifications/type/_comment.haml
@@ -17,7 +17,7 @@
       - else
         = t(".heading_html",
               user: user_screen_name(notification.target.user),
-              answer: link_to(t(".other.link_text_html", user: user_screen_name(notification.target.answer.user)), answer_path(username: notification.target.user.screen_name, id: notification.target.answer.id)),
+              answer: link_to(t(".other.link_text_html", user: user_screen_name(notification.target.answer.user, url: false)), answer_path(username: notification.target.user.screen_name, id: notification.target.answer.id)),
               time: time_tooltip(notification.target))
     .list-group
       .list-group-item


### PR DESCRIPTION
In cases someone commented on an answer of someone else that you were subscribed to, the link before was

```
[testdesu2](http://localhost:3000/@testdesu2) commented on [testdesu's](http://localhost:3000/@testdesu) answer about 2 months ago
```

This only linked to the user that commented, but not to their answer, the link is now this instead:

```
[testdesu2](http://localhost:3000/@testdesu2) commented on [testdesu's answer](http://localhost:3000/@testdesu2/a/108658846144322893) about 2 months ago
```