### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+
+[*.md]
+# two spaces at the end of a line create a linebreak
+trim_trailing_whitespace = false


### PR DESCRIPTION
this file is loaded by e.g. Kate and RubyMine automatically to ensure consistent indentation (we seem to use 2 spaces everywhere), the final line break, and no trailing spaces (except in Markdown files).  
VS Code users need to install the extension: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
