### PR TITLE
Disable Turbo for all Devise forms

### DIFF
--- a/app/views/devise/confirmations/new.haml
+++ b/app/views/devise/confirmations/new.haml
@@ -5,7 +5,7 @@
       .card.mt-3
         .card-body
           %h1 Resend confirmation instructions
-          = bootstrap_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+          = bootstrap_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { turbo: false }) do |f|
             = render 'devise/shared/error_messages', resource: resource
 
             = f.text_field :screen_name, autofocus: true, label: 'User name'

--- a/app/views/devise/passwords/edit.haml
+++ b/app/views/devise/passwords/edit.haml
@@ -5,7 +5,7 @@
       .card.mt-3
         .card-body
           %h1 Change your password
-          = bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+          = bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { turbo: false }) do |f|
             = render 'devise/shared/error_messages', resource: resource
 
             = f.hidden_field :reset_password_token

--- a/app/views/devise/passwords/new.haml
+++ b/app/views/devise/passwords/new.haml
@@ -5,7 +5,7 @@
       .card.mt-3
         .card-body
           %h1 Forgot your password?
-          = bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+          = bootstrap_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: { turbo: false }) do |f|
             = render 'devise/shared/error_messages', resource: resource
 
             = f.email_field :email, autofocus: true, label: 'Email address'

--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -5,7 +5,7 @@
       .card.mt-3
         .card-body
           %h1= t(".title")
-          = bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+          = bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }) do |f|
             = render "devise/shared/error_messages", resource: resource
             = render "layouts/messages"
 

--- a/app/views/devise/sessions/new.haml
+++ b/app/views/devise/sessions/new.haml
@@ -6,7 +6,7 @@
       .card.mt-3
         .card-body
           %h1.mb-3.mt-0= t(".title")
-          = bootstrap_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+          = bootstrap_form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: false }) do |f|
 
             = f.text_field :login, autofocus: true, autocomplete: :username
             = f.password_field :password, autocomplete: "current-password"

--- a/app/views/devise/unlocks/new.haml
+++ b/app/views/devise/unlocks/new.haml
@@ -3,7 +3,7 @@
   %h1 Resend unlock instructions
   = render 'layouts/messages'
 
-  = bootstrap_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = bootstrap_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, data: { turbo: false }) do |f|
     = render 'devise/shared/error_messages', resource: resource
 
     = f.email_field :email, autofocus: true, label: 'Email address'


### PR DESCRIPTION
Turbo form handling breaks login and registration, this is the same that has been done for the settings forms in the intial implementation branch.