### PR TITLE
Use updated Node version

### DIFF
--- a/.docker/ruby/Dockerfile
+++ b/.docker/ruby/Dockerfile
@@ -8,7 +8,7 @@ ARG GID=1000
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends build-essential \

--- a/.docker/ruby/Dockerfile
+++ b/.docker/ruby/Dockerfile
@@ -8,7 +8,7 @@ ARG GID=1000
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends build-essential \

--- a/.github/workflows/retrospring.yml
+++ b/.github/workflows/retrospring.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Node 12
         uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '18'
       - name: Copy default configuration
         run: |
           cp config/database.yml.postgres config/database.yml

--- a/.github/workflows/retrospring.yml
+++ b/.github/workflows/retrospring.yml
@@ -48,10 +48,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Set up Node 12
+      - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
       - name: Copy default configuration
         run: |
           cp config/database.yml.postgres config/database.yml

--- a/babel.config.js
+++ b/babel.config.js
@@ -49,6 +49,18 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true
+        }
+      ],
+      [
+        '@babel/plugin-proposal-private-property-in-object',
+        {
+          loose: true
+        }
+      ],
+      [
         '@babel/plugin-proposal-object-rest-spread',
         {
           useBuiltIns: true

--- a/babel.config.js
+++ b/babel.config.js
@@ -34,12 +34,12 @@ module.exports = function(api) {
           modules: false,
           exclude: ['transform-typeof-symbol']
         }
-      ],
-      ['@babel/preset-typescript', { 'allExtensions': true, 'isTSX': true }]
+      ]
     ].filter(Boolean),
     plugins: [
       'babel-plugin-macros',
       '@babel/plugin-syntax-dynamic-import',
+      ["@babel/plugin-transform-typescript", { 'allExtensions': true, 'isTSX': true, 'allowDeclareFields': true }],
       isTestEnv && 'babel-plugin-dynamic-import-node',
       '@babel/plugin-transform-destructuring',
       [

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "lint:fix": "yarn run eslint --ext .ts app/javascript --fix"
   },
   "dependencies": {
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@hotwired/turbo-rails": "^7.1.3",
     "@melloware/coloris": "^0.16.1",


### PR DESCRIPTION
Retrospring's setup is using Node 12, which is criminally outdated.

This PR updates the setup to work with Node 16. Locally it builds fine, this checks if GitHub Actions also runs fine.