### PR TITLE
Downgrade bootstrap_form to match Bootstrap version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "bcrypt", "~> 3.1.18"
 
 gem "active_model_otp"
 gem "bootsnap", require: false
-gem "bootstrap_form"
+gem "bootstrap_form", "~> 4.5"
 gem "carrierwave", "~> 2.0"
 gem "carrierwave_backgrounder", git: "https://github.com/mltnhm/carrierwave_backgrounder.git"
 gem "colorize"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
-    bootstrap_form (5.1.0)
+    bootstrap_form (4.5.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
     brakeman (5.3.1)
@@ -580,7 +580,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  bootstrap_form
+  bootstrap_form (~> 4.5)
   brakeman
   bullet
   byebug


### PR DESCRIPTION
Bootstrap forms don't change too much from version 4 to 5, but the visibility class that is used to hide labels does, which caused showing labels in places where they weren't before.

Ex. inbox author search:

current (main)
![image](https://user-images.githubusercontent.com/1774242/194708961-d4bcd74f-9aae-4787-8fa6-afb6f36e2b94.png)

PR
![image](https://user-images.githubusercontent.com/1774242/194708972-0cef0b86-c632-4a93-835e-e827e462b048.png)
