### PR TITLE
Install i18n-js 4 2: Electric Boogaloo

### DIFF
--- a/.github/workflows/retrospring.yml
+++ b/.github/workflows/retrospring.yml
@@ -61,7 +61,7 @@ jobs:
           npm i -g yarn
           yarn install --frozen-lockfile
       - name: Export i18n JS files
-        run: bundle exec rails i18n:js:export
+        run: bundle exec i18n export
       - name: Compile assets
         run:
           bundle exec rake assets:precompile

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ coverage/
 *~
 
 # dont push generated js translations to repository
-/app/javascript/retrospring/i18n.ts
+/app/javascript/retrospring/i18n.json
 
 # every fucking time, dolphin
 .directory

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "i18n-js", "3.9.2"
+gem "i18n-js", "4.0"
 gem "rails", "~> 6.1"
 gem "rails-i18n", "~> 6.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    glob (0.3.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
     guard (2.18.0)
@@ -241,8 +242,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    i18n-js (3.9.2)
-      i18n (>= 0.6.6)
+    i18n-js (4.0.0)
+      glob
+      i18n
     idn-ruby (0.1.4)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
@@ -597,7 +599,7 @@ DEPENDENCIES
   haml_lint
   hcaptcha (~> 7.0)
   httparty
-  i18n-js (= 3.9.2)
+  i18n-js (= 4.0)
   jbuilder (~> 2.10)
   jwt (~> 2.5)
   letter_opener

--- a/app/javascript/retrospring/i18n.ts
+++ b/app/javascript/retrospring/i18n.ts
@@ -1,0 +1,12 @@
+
+import Cookies from 'js-cookie'
+import { I18n } from "i18n-js"
+import translations from "./i18n.json";
+
+const i18n = new I18n();
+i18n.store(translations);
+i18n.defaultLocale = "en";
+i18n.enableFallback = true;
+i18n.locale = Cookies.get('hl') || 'en';
+
+export default i18n;

--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -21,12 +21,9 @@
 # If you're running an old version, you can use something
 # like this:
 #
-fallbacks: :default_locale
-
-export_i18n_js: false
-
 translations:
-  - file: 'app/javascript/retrospring/i18n.ts'
-    only: ['*.voc.*', '*.frontend.*', '*.views.actions.*']
-    prefix: "import I18n from 'i18n-js'\nimport Cookies from 'js-cookie'\n"
-    suffix: "I18n.defaultLocale = 'en';\nI18n.locale = Cookies.get('hl') || 'en';\nexport default I18n"
+  - file: 'app/javascript/retrospring/i18n.json'
+    patterns:
+      - '*.voc.*'
+      - '*.frontend.*'
+      - '*.views.actions.*'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "core-js": "^3.25.5",
     "croppr": "^2.3.1",
     "font-awesome": "4.7.0",
-    "i18n-js": "^3.9.2",
+    "i18n-js": "^4.0",
     "jquery": "^3.6.1",
     "js-cookie": "2.2.1",
     "lato-font": "^3.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["es6", "dom"],
     "module": "es6",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
         "*": ["node_modules/*", "app/javascript/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,6 +1990,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@*:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
+  integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -4157,10 +4162,13 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-i18n-js@^3.9.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-3.9.2.tgz#4a015dcfabd4c9fc73115fc2d02d2627e4c15ca5"
-  integrity sha512-+Gm8h5HL0emzKhRx2avMKX+nKiVPXeaOZm7Euf2/pbbFcLQoJ3zZYiUykAzoRasijCoWos2Kl1tslmScTgAQKw==
+i18n-js@^4.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-4.1.1.tgz#05ebd03c4d92f6dc26a00d7c5cfb90f9c326b67c"
+  integrity sha512-Uph8ghmfShexVhDcNtg5s40zprJZPrhW5iOEKsUwPiiBpIGN/0EJ9W7DTqhLFlWfAlpkFiaLxVxHsk8f+3KjIQ==
+  dependencies:
+    bignumber.js "*"
+    lodash "*"
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -4839,7 +4847,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.5:
+lodash@*, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
_I love breaking changes everywhere! **Now without additional dependency updates!**_

> **Warning**
> This requires a change in the deployment after being merged

This pretty much changes up how `i18n-js` works in most parts configuration-wise. A new (non-rake) CLI, new configuration (including default path) that dropped 90% of the available options, and the JS side also changing how it works.

Anyway, works now.

**Testing:**
```
bundle i18n export
```
and then try to open a confirm dialog, (un)subscribing to notifications or anything else that has frontend locales.