### PR TITLE
Fix profile menu direction on desktop

### DIFF
--- a/app/views/navigation/dropdown/_profile.haml
+++ b/app/views/navigation/dropdown/_profile.haml
@@ -1,4 +1,4 @@
-.dropdown-menu.profile-dropdown{ id: "rs-#{size}-nav-profile" }
+.dropdown-menu.dropdown-menu-right.profile-dropdown{ id: "rs-#{size}-nav-profile" }
   %h6.dropdown-header.d-none.d-sm-block= current_user.screen_name
   %a.dropdown-item{ href: user_path(current_user) }
     %i.fa.fa-fw.fa-user


### PR DESCRIPTION
Before:
<img width="1280" alt="Screenshot 2022-10-12 at 00 03 02" src="https://user-images.githubusercontent.com/6197148/195206771-e4868738-ef8d-46e4-85a2-1bb1c657bc15.png">

After:
<img width="1280" alt="Screenshot 2022-10-12 at 00 03 18" src="https://user-images.githubusercontent.com/6197148/195206806-4a58f50d-3b57-4b9a-9757-7f9325700891.png">
