### PR TITLE
typoed_email_validator: check for valid TLDs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem "redis"
 
 gem "fake_email_validator"
 
+# TLD validation
+gem "tldv", "~> 0.1.0"
+
 gem "jwt", "~> 2.5"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,6 +518,9 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.11)
     timeout (0.3.0)
+    tldv (0.1.0)
+      tldv-data (~> 1.0)
+    tldv-data (1.0.2022101300)
     turbo-rails (1.1.1)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -641,6 +644,7 @@ DEPENDENCIES
   simplecov-cobertura
   simplecov-json
   spring (~> 4.1)
+  tldv (~> 0.1.0)
   turbo-rails
   twitter
   twitter-text

--- a/spec/controllers/user/registration_controller_spec.rb
+++ b/spec/controllers/user/registration_controller_spec.rb
@@ -30,7 +30,7 @@ describe User::RegistrationsController, type: :controller do
         {
           user: {
             screen_name:           "dio",
-            email:                 "the-world-21@somewhere.everywhere",
+            email:                 "the-world-21@somewhere.everywhere.now",
             password:              "AReallySecurePassword456!",
             password_confirmation: "AReallySecurePassword456!"
           }
@@ -85,7 +85,7 @@ describe User::RegistrationsController, type: :controller do
           {
             user: {
               screen_name:           "Dio Brando",
-              email:                 "the-world-21@somewhere.everywhere",
+              email:                 "the-world-21@somewhere.everywhere.now",
               password:              "AReallySecurePassword456!",
               password_confirmation: "AReallySecurePassword456!"
             }
@@ -102,7 +102,7 @@ describe User::RegistrationsController, type: :controller do
           {
             user: {
               screen_name:           "moderator",
-              email:                 "the-world-21@somewhere.everywhere",
+              email:                 "the-world-21@somewhere.everywhere.now",
               password:              "AReallySecurePassword456!",
               password_confirmation: "AReallySecurePassword456!"
             }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe User, type: :model do
     include_examples "valid email", "fritz.fantom@protonmail.com"
     include_examples "valid email", "fritz.fantom@example.email"
     include_examples "valid email", "fritz.fantom@enterprise.k8s.420stripes.k8s.needs.more.k8s.jira.atlassian.k8s.eu-central-1.s3.amazonaws.com"
+    include_examples "valid email", "fritz.fantom@emacs.horse"
     include_examples "invalid email", "@jack"
 
     # examples from the real world:


### PR DESCRIPTION
i'm sure there are many more typos waiting to happen.  one thing we can already catch though is the usage of invalid TLDs.

this makes use of my new TLDv gem -- the data it uses can be updated independently from the main gem.