### PR TITLE
Use data-turbo-method for mod (un)masking link

### DIFF
--- a/app/views/navigation/dropdown/_profile.haml
+++ b/app/views/navigation/dropdown/_profile.haml
@@ -23,11 +23,11 @@
     .dropdown-divider
   - if current_user.mod?
     - if moderation_view?
-      = link_to moderation_toggle_unmask_path, method: :post, class: "dropdown-item" do
+      = link_to moderation_toggle_unmask_path, class: "dropdown-item", data: { turbo_method: :post } do
         %i.fa.fa-toggle-on
         = t(".unmask.disable")
     - else
-      = link_to moderation_toggle_unmask_path, method: :post, class: "dropdown-item" do
+      = link_to moderation_toggle_unmask_path, class: "dropdown-item", data: { turbo_method: :post } do
         %i.fa.fa-toggle-off
         = t(".unmask.enable")
     %a.dropdown-item{ href: mod_anon_block_index_path }


### PR DESCRIPTION
This fixes the 404 when clicking the _Moderation View_ links in the navigation dropdown.

It does not fix that now the redirect isn't working (it triggers a Turbo Streams response) but I haven't found a way to work around that yet, for now this is better than a breaking functionality.