### PR TITLE
Prevent comments from submitting after input as composition ends

### DIFF
--- a/app/javascript/retrospring/features/answerbox/comment/index.ts
+++ b/app/javascript/retrospring/features/answerbox/comment/index.ts
@@ -1,7 +1,7 @@
 import registerEvents from "retrospring/utilities/registerEvents"
 import { commentCharacterCountHandler } from "./count";
 import { commentDestroyHandler } from "./destroy";
-import { commentCreateHandler } from "./new";
+import {commentComposeEnd, commentComposeStart, commentCreateHandler} from "./new";
 import { commentReportHandler } from "./report";
 import { commentSmileHandler } from "./smile";
 import { commentToggleHandler } from "./toggle";
@@ -12,6 +12,8 @@ export default (): void => {
     { type: 'click', target: '[name=ab-smile-comment]', handler: commentSmileHandler, global: true },
     { type: 'click', target: '[data-action=ab-comment-report]', handler: commentReportHandler, global: true },
     { type: 'click', target: '[data-action=ab-comment-destroy]', handler: commentDestroyHandler, global: true },
+    { type: 'compositionstart', target: '[name=ab-comment-new]', handler: commentComposeStart, global: true },
+    { type: 'compositionend', target: '[name=ab-comment-new]', handler: commentComposeEnd, global: true },
     { type: 'keyup', target: '[name=ab-comment-new]', handler: commentCreateHandler, global: true },
     { type: 'input', target: '[name=ab-comment-new]', handler: commentCharacterCountHandler, global: true }
   ]);

--- a/app/javascript/retrospring/features/answerbox/comment/new.ts
+++ b/app/javascript/retrospring/features/answerbox/comment/new.ts
@@ -3,7 +3,14 @@ import { post } from '@rails/request.js';
 import I18n from 'retrospring/i18n';
 import { showNotification, showErrorNotification } from 'utilities/notifications';
 
+let compositionJustEnded = false;
+
 export function commentCreateHandler(event: KeyboardEvent): boolean {
+  if (compositionJustEnded && event.which == 13) {
+    compositionJustEnded = false;
+    return;
+  }
+
   const input = event.target as HTMLInputElement;
   const id = input.dataset.aId;
   const counter = document.querySelector(`#ab-comment-charcount-${id}`);
@@ -50,4 +57,14 @@ export function commentCreateHandler(event: KeyboardEvent): boolean {
         input.disabled = false;
       });
   }
+}
+
+export function commentComposeStart(): boolean {
+  compositionJustEnded = false;
+  return true;
+}
+
+export function commentComposeEnd(): boolean {
+  compositionJustEnded = true;
+  return true;
 }


### PR DESCRIPTION
Closes #5 

Tested with Japanese input on:

- Firefox 106 on macOS 13
- Safari 16.1 on macOS 13
- Firefox 106 on Windows 11
- Safari on iOS 16.1

Testing:

- Post a comment with text without using an IME
- Post a comment with multiple composed words while using an IME