### PR TITLE
Remove unused debugging methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,9 +72,7 @@ gem "jwt", "~> 2.5"
 
 group :development do
   gem "binding_of_caller"
-  gem "byebug"
   gem "spring", "~> 4.1"
-  gem "web-console", "~> 4.0"
 end
 
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     bootsnap (1.13.0)
@@ -96,7 +95,6 @@ GEM
     bullet (7.0.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
     capybara (3.37.1)
       addressable
       matrix
@@ -518,11 +516,6 @@ GEM
     uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (4.2.0)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -546,7 +539,6 @@ DEPENDENCIES
   bootsnap
   bootstrap_form (~> 4.5)
   bullet
-  byebug
   capybara
   carrierwave (~> 2.0)
   carrierwave_backgrounder!
@@ -616,7 +608,6 @@ DEPENDENCIES
   turbo-rails
   twitter
   twitter-text
-  web-console (~> 4.0)
   webpacker (~> 5.2)
 
 BUNDLED WITH


### PR DESCRIPTION
We never used `byebug` and `web-console`, or at least not in the past 6 years or so.