### PR TITLE
Add user requirement option for users

### DIFF
--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -9,7 +9,8 @@ class Settings::PrivacyController < ApplicationController
     user_attributes = params.require(:user).permit(:privacy_allow_anonymous_questions,
                                                    :privacy_allow_public_timeline,
                                                    :privacy_allow_stranger_answers,
-                                                   :privacy_show_in_search)
+                                                   :privacy_show_in_search,
+                                                   :privacy_require_user)
     if current_user.update(user_attributes)
       flash[:success] = t(".success")
     else

--- a/app/views/application/_questionbox.html.haml
+++ b/app/views/application/_questionbox.html.haml
@@ -14,6 +14,9 @@
     - elsif user_signed_in? && user.blocking?(current_user)
       .text-center
         %strong= t(".status.blocked")
+    - elsif !user_signed_in? && user.privacy_require_user?
+      .text-center
+        %strong= t(".status.require_user_html", sign_in: link_to(t("voc.login"), new_user_session_path), sign_up: link_to(t("voc.register"), new_user_registration_path))
     - else
       - if user_signed_in? || user.privacy_allow_anonymous_questions?
         #question-box{ data: { controller: "character-count", "character-count-max-value": 512 }}
@@ -51,4 +54,5 @@
               .col-xs-12.col-sm-10.offset-sm-1.text-center
                 %small= t(".promote.join", app_title: APP_CONFIG["site_name"])
         - else
-          %p= raw t(".required", signup: link_to(t("voc.register"), new_user_registration_path))
+          .text-center
+            %strong= t(".status.non_anonymous_html", sign_in: link_to(t("voc.login"), new_user_session_path), sign_up: link_to(t("voc.register"), new_user_registration_path))

--- a/app/views/settings/privacy/edit.html.haml
+++ b/app/views/settings/privacy/edit.html.haml
@@ -2,6 +2,7 @@
   .card-body
     = bootstrap_form_for(current_user, url: settings_privacy_path, method: :patch, data: { turbo: false }) do |f|
       = f.check_box :privacy_allow_anonymous_questions
+      = f.check_box :privacy_require_user
       = f.check_box :privacy_allow_public_timeline
       = f.check_box :privacy_allow_stranger_answers
 

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -68,6 +68,7 @@ en:
         password: "Password"
         password_confirmation: "Confirm your password"
         privacy_allow_anonymous_questions: "Allow anonymous questions"
+        privacy_require_user: "Require users to be logged in to ask you questions"
         privacy_allow_public_timeline: "Show your answers in the public timeline"
         privacy_allow_stranger_answers: "Allow other people to answer your questions"
         profile_picture: "Profile picture"

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -33,3 +33,5 @@ en:
     invalid_parameter: "Invalid parameter"
 
     record_not_found: "Record not found"
+
+    login_required: "You need to be logged in to perform this action"

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -34,4 +34,4 @@ en:
 
     record_not_found: "Record not found"
 
-    login_required: "You need to be logged in to perform this action"
+    not_authorized: "You need to be logged in to perform this action"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -110,7 +110,6 @@ en:
       hide: "Answered by"
     questionbox:
       title: "Ask something!"
-      required: "This user does not want to get asked by strangers.  Why don't you %{signup}?"
       placeholder: "Type your question here…"
       anonymous: "Hide your name"
       load: "Asking…"
@@ -123,6 +122,12 @@ en:
         banned: "This user got hit with ye olde banhammer."
         blocking: "You are blocking this user."
         blocked: "This user has blocked you."
+        require_user_html: |
+          This user requires others to be logged in to ask questions. <br/>
+          (%{sign_in} or %{sign_up})
+        non_anonymous_html: |
+          This user does not want to receive anonymous questions. <br/>
+          (%{sign_in} or %{sign_up})
   devise:
     registrations:
       edit:

--- a/db/migrate/20221113110942_add_privacy_require_user_to_users.rb
+++ b/db/migrate/20221113110942_add_privacy_require_user_to_users.rb
@@ -1,0 +1,9 @@
+class AddPrivacyRequireUserToUsers < ActiveRecord::Migration[6.1]
+  def up
+    add_column :users, :privacy_require_user, :boolean, default: false
+  end
+
+  def down
+    remove_column :users, :privacy_require_user
+  end
+end

--- a/db/migrate/20221113110942_add_privacy_require_user_to_users.rb
+++ b/db/migrate/20221113110942_add_privacy_require_user_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPrivacyRequireUserToUsers < ActiveRecord::Migration[6.1]
   def up
     add_column :users, :privacy_require_user, :boolean, default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_20_163035) do
 ActiveRecord::Schema.define(version: 2022_11_13_110942) do
 
   # These are extensions that must be enabled in order to support this database

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -301,6 +301,7 @@ ActiveRecord::Schema.define(version: 2022_08_20_163035) do
     t.string "otp_secret_key"
     t.integer "otp_module", default: 0, null: false
     t.datetime "deleted_at"
+    t.boolean "privacy_require_user", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_08_20_163035) do
+ActiveRecord::Schema.define(version: 2022_11_13_110942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -44,14 +44,17 @@ module Errors
     end
   end
 
+  class NotAuthorized < Base
+    def status
+      401
+    end
+  end
+
   class UserNotFound < NotFound
   end
 
   # region User Blocking
   class Blocked < Forbidden
-  end
-
-  class LoginRequired < Forbidden
   end
 
   class OtherBlockedSelf < Blocked

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -51,6 +51,9 @@ module Errors
   class Blocked < Forbidden
   end
 
+  class LoginRequired < Forbidden
+  end
+
   class OtherBlockedSelf < Blocked
   end
 

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -14,6 +14,7 @@ module UseCase
       option :direct, type: Types::Params::Bool, default: proc { true }
 
       def call
+        check_user
         check_anonymous_rules
         check_blocks
 
@@ -57,6 +58,10 @@ module UseCase
 
         raise Errors::AskingOtherBlockedSelf if target_user.blocking?(source_user)
         raise Errors::AskingSelfBlockedOther if source_user.blocking?(target_user)
+      end
+
+      def check_user
+        raise Errors::LoginRequired if target_user.privacy_require_user && !source_user_id
       end
 
       def increment_asked_count

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -61,7 +61,7 @@ module UseCase
       end
 
       def check_user
-        raise Errors::LoginRequired if target_user.privacy_require_user && !source_user_id
+        raise Errors::NotAuthorized if target_user.privacy_require_user && !source_user_id
       end
 
       def increment_asked_count

--- a/spec/lib/use_case/question/create_spec.rb
+++ b/spec/lib/use_case/question/create_spec.rb
@@ -44,6 +44,12 @@ describe UseCase::Question::Create do
     end
   end
 
+  shared_examples "not authorized" do
+    it "raises an error" do
+      expect { subject }.to raise_error(Errors::NotAuthorized)
+    end
+  end
+
   shared_examples "validates content" do
     context "content is empty" do
       let(:content) { "" }
@@ -186,7 +192,7 @@ describe UseCase::Question::Create do
           target_user.update!(privacy_require_user: true)
         end
 
-        it_behaves_like "forbidden"
+        it_behaves_like "not authorized"
       end
     end
   end

--- a/spec/lib/use_case/question/create_spec.rb
+++ b/spec/lib/use_case/question/create_spec.rb
@@ -175,6 +175,19 @@ describe UseCase::Question::Create do
           it_behaves_like "invalid params"
         end
       end
+
+      context "target user does not allow non-logged in questions" do
+        let(:allow_anon) { true }
+        let(:anonymous) { true }
+        let(:content) { "Hello world" }
+        let(:author_identifier) { "qwerty" }
+
+        before do
+          target_user.update!(privacy_require_user: true)
+        end
+
+        it_behaves_like "forbidden"
+      end
     end
   end
 end


### PR DESCRIPTION
To prevent harassment a bit more users can now require users to have an account to ask (anonymous) questions.

![image](https://user-images.githubusercontent.com/1774242/201524309-20cde903-5181-495c-b001-baf0138e4c96.png)
