### PR TITLE
Add setting to hide a users social graph

### DIFF
--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -11,7 +11,8 @@ class Settings::PrivacyController < ApplicationController
                                                    :privacy_allow_public_timeline,
                                                    :privacy_allow_stranger_answers,
                                                    :privacy_show_in_search,
-                                                   :privacy_require_user)
+                                                   :privacy_require_user,
+                                                   :privacy_hide_social_graph)
     if current_user.update(user_attributes)
       flash[:success] = t(".success")
     else

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserController < ApplicationController
   before_action :set_user
   before_action :hidden_social_graph_redirect, only: %i[followers followings]
@@ -22,7 +24,7 @@ class UserController < ApplicationController
   end
 
   def followers
-    @title = 'Followers'
+    @title = "Followers"
     @relationships = @user.cursored_follower_relationships(last_id: params[:last_id])
     @relationships_last_id = @relationships.map(&:id).min
     @more_data_available = !@user.cursored_follower_relationships(last_id: @relationships_last_id, size: 1).count.zero?
@@ -35,9 +37,8 @@ class UserController < ApplicationController
     end
   end
 
-  # rubocop:disable Metrics/AbcSize
   def followings
-    @title = 'Following'
+    @title = "Following"
     @relationships = @user.cursored_following_relationships(last_id: params[:last_id])
     @relationships_last_id = @relationships.map(&:id).min
     @more_data_available = !@user.cursored_following_relationships(last_id: @relationships_last_id, size: 1).count.zero?
@@ -49,10 +50,9 @@ class UserController < ApplicationController
       format.turbo_stream { render "show_follow" }
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def questions
-    @title = 'Questions'
+    @title = "Questions"
     @questions = @user.cursored_questions(author_is_anonymous: false, direct: belongs_to_current_user? || moderation_view?, last_id: params[:last_id])
     @questions_last_id = @questions.map(&:id).min
     @more_data_available = !@user.cursored_questions(author_is_anonymous: false, direct: belongs_to_current_user? || moderation_view?, last_id: @questions_last_id, size: 1).count.zero?
@@ -66,13 +66,13 @@ class UserController < ApplicationController
   private
 
   def set_user
-    @user = User.where('LOWER(screen_name) = ?', params[:username].downcase).includes(:profile).first!
+    @user = User.where("LOWER(screen_name) = ?", params[:username].downcase).includes(:profile).first!
   end
 
   def hidden_social_graph_redirect
-    unless belongs_to_current_user? || !@user.privacy_hide_social_graph
-      redirect_to user_path(@user)
-    end
+    return if belongs_to_current_user? || !@user.privacy_hide_social_graph
+
+    redirect_to user_path(@user)
   end
 
   def belongs_to_current_user? = @user == current_user

--- a/app/views/settings/privacy/edit.html.haml
+++ b/app/views/settings/privacy/edit.html.haml
@@ -6,6 +6,7 @@
       = f.check_box :privacy_require_user
       = f.check_box :privacy_allow_public_timeline
       = f.check_box :privacy_allow_stranger_answers
+      = f.check_box :privacy_hide_social_graph
 
       = f.primary
 

--- a/app/views/tabs/_profile.html.haml
+++ b/app/views/tabs/_profile.html.haml
@@ -2,5 +2,6 @@
   .list-group.list-group-horizontal-sm.text-center
     = list_group_item t(".answers"), user_path(user), badge: user.answered_count
     = list_group_item t(".questions"), show_user_questions_path(user.screen_name), badge: user.asked_count
-    = list_group_item t(".followers"), show_user_followers_path(user.screen_name), badge: user.followers.count
-    = list_group_item t(".following"), show_user_followings_path(user.screen_name), badge: user.followings.count
+    - if user == current_user || !user.privacy_hide_social_graph
+      = list_group_item t(".followers"), show_user_followers_path(user.screen_name), badge: user.followers.count
+      = list_group_item t(".following"), show_user_followings_path(user.screen_name), badge: user.followings.count

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -72,7 +72,7 @@ en:
         privacy_require_user: "Require users to be logged in to ask you questions"
         privacy_allow_public_timeline: "Show your answers in the public timeline"
         privacy_allow_stranger_answers: "Allow other people to answer your questions"
-        privacy_hide_social_graph: "Hide your social graph"
+        privacy_hide_social_graph: "Hide your social graph from others"
         profile_picture: "Profile picture"
         profile_header: "Profile header"
         sign_in_count: "Sign in count"

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -72,6 +72,7 @@ en:
         privacy_require_user: "Require users to be logged in to ask you questions"
         privacy_allow_public_timeline: "Show your answers in the public timeline"
         privacy_allow_stranger_answers: "Allow other people to answer your questions"
+        privacy_hide_social_graph: "Hide your social graph"
         profile_picture: "Profile picture"
         profile_header: "Profile header"
         sign_in_count: "Sign in count"

--- a/db/migrate/20221115194933_add_privacy_hide_social_graph.rb
+++ b/db/migrate/20221115194933_add_privacy_hide_social_graph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPrivacyHideSocialGraph < ActiveRecord::Migration[6.1]
   def up
     add_column :users, :privacy_hide_social_graph, :boolean, default: false

--- a/db/migrate/20221115194933_add_privacy_hide_social_graph.rb
+++ b/db/migrate/20221115194933_add_privacy_hide_social_graph.rb
@@ -1,0 +1,9 @@
+class AddPrivacyHideSocialGraph < ActiveRecord::Migration[6.1]
+  def up
+    add_column :users, :privacy_hide_social_graph, :boolean, default: false
+  end
+
+  def down
+    remove_column :users, :privacy_hide_social_graph
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -228,7 +228,6 @@ ActiveRecord::Schema.define(version: 2022_11_15_194933) do
     t.integer "raised_accent", default: 16250871
     t.integer "light_color", default: 16316922
     t.integer "light_text", default: 0
-    t.integer "input_placeholder", default: 7107965, null: false
     t.index ["user_id", "created_at"], name: "index_themes_on_user_id_and_created_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_13_110942) do
+ActiveRecord::Schema.define(version: 2022_11_15_194933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 2022_11_13_110942) do
     t.integer "raised_accent", default: 16250871
     t.integer "light_color", default: 16316922
     t.integer "light_text", default: 0
+    t.integer "input_placeholder", default: 7107965, null: false
     t.index ["user_id", "created_at"], name: "index_themes_on_user_id_and_created_at"
   end
 
@@ -292,9 +293,9 @@ ActiveRecord::Schema.define(version: 2022_11_13_110942) do
     t.datetime "export_created_at"
     t.string "otp_secret_key"
     t.integer "otp_module", default: 0, null: false
-    t.datetime "deleted_at"
-    t.boolean "privacy_require_user", default: false
     t.boolean "privacy_lock_inbox", default: false
+    t.boolean "privacy_require_user", default: false
+    t.boolean "privacy_hide_social_graph", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -9,6 +9,32 @@ describe UserController, type: :controller do
                       otp_secret_key: "EJFNIJPYXXTCQSRTQY6AG7XQLAT2IDG5H7NGLJE3"
   end
 
+  shared_examples_for "social graph hidden" do
+    context "user has social graph hidden" do
+      before(:each) do
+        user.update(privacy_hide_social_graph: true)
+      end
+
+      it "shows the followers template to the current user" do
+        sign_in user
+        subject
+        expect(assigns(:user)).to eq(user)
+        expect(response).to render_template("user/show_follow")
+      end
+
+      it "redirects to the user profile page if not logged in" do
+        subject
+        expect(response).to redirect_to(user_path(user))
+      end
+
+      it "redirects to the user profile page if logged in as a different user" do
+        sign_in FactoryBot.create(:user)
+        subject
+        expect(response).to redirect_to(user_path(user))
+      end
+    end
+  end
+
   describe "#show" do
     subject { get :show, params: { username: user.screen_name } }
 
@@ -35,6 +61,8 @@ describe UserController, type: :controller do
         expect(response).to render_template("user/show_follow")
       end
     end
+
+    include_examples "social graph hidden"
   end
 
   describe "#followings" do
@@ -49,6 +77,8 @@ describe UserController, type: :controller do
         expect(response).to render_template("user/show_follow")
       end
     end
+
+    include_examples "social graph hidden"
   end
 
   describe "#questions" do


### PR DESCRIPTION
If someone doesn't want to show their followers/followings to the world!

The current user can view their own followings still, guests and other users won't see the tabs. Trying to access the views by URL redirects to the main profile page.

**Screenshot:**
![image](https://user-images.githubusercontent.com/1774242/202021827-0df88e09-8347-4562-93d9-2f9ee55d6bdf.png)

**Testing:**
* Test the setting if the counts are hidden properly and that accessing the views does not work.

Closes #543 