### PR TITLE
Add setting to disable search indexing for a user

### DIFF
--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -11,7 +11,8 @@ class Settings::PrivacyController < ApplicationController
                                                    :privacy_allow_public_timeline,
                                                    :privacy_allow_stranger_answers,
                                                    :privacy_show_in_search,
-                                                   :privacy_require_user)
+                                                   :privacy_require_user,
+                                                   :privacy_noindex)
     if current_user.update(user_attributes)
       flash[:success] = t(".success")
     else

--- a/app/views/layouts/base.html.haml
+++ b/app/views/layouts/base.html.haml
@@ -9,6 +9,8 @@
       %meta{ name: 'theme-color', content: mobile_theme_color, media: '(max-width: 992px)' }
     - else
       %meta{ name: 'theme-color', content: theme_color }
+    - if @user&.privacy_noindex? || @answer&.user&.privacy_noindex? || @question&.user&.privacy_noindex?
+      %meta{ name: 'robots', content: 'noindex' }
     %link{ rel: 'manifest', href: '/manifest.json', crossorigin: 'use-credentials' }
     %link{ rel: 'apple-touch-icon', href: '/icons/maskable_icon_x192.png' }
     %link{ rel: 'mask-icon', href: '/icons/icon.svg', color: theme_color }

--- a/app/views/settings/privacy/edit.html.haml
+++ b/app/views/settings/privacy/edit.html.haml
@@ -6,6 +6,7 @@
       = f.check_box :privacy_require_user
       = f.check_box :privacy_allow_public_timeline
       = f.check_box :privacy_allow_stranger_answers
+      = f.check_box :privacy_noindex
 
       = f.primary
 

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -72,6 +72,7 @@ en:
         privacy_require_user: "Require users to be logged in to ask you questions"
         privacy_allow_public_timeline: "Show your answers in the public timeline"
         privacy_allow_stranger_answers: "Allow other people to answer your questions"
+        privacy_noindex: "Prevent search engines from indexing your profile"
         profile_picture: "Profile picture"
         profile_header: "Profile header"
         sign_in_count: "Sign in count"

--- a/db/migrate/20221116201723_add_privacy_noindex_to_user.rb
+++ b/db/migrate/20221116201723_add_privacy_noindex_to_user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddPrivacyNoindexToUser < ActiveRecord::Migration[6.1]
+  def up
+    add_column :users, :privacy_noindex, :boolean, default: false
+  end
+
+  def down
+    remove_column :users, :privacy_noindex
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_13_110942) do
+ActiveRecord::Schema.define(version: 2022_11_16_201723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -292,9 +292,9 @@ ActiveRecord::Schema.define(version: 2022_11_13_110942) do
     t.datetime "export_created_at"
     t.string "otp_secret_key"
     t.integer "otp_module", default: 0, null: false
-    t.datetime "deleted_at"
-    t.boolean "privacy_require_user", default: false
     t.boolean "privacy_lock_inbox", default: false
+    t.boolean "privacy_require_user", default: false
+    t.boolean "privacy_noindex", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -296,6 +296,7 @@ ActiveRecord::Schema.define(version: 2022_11_16_201723) do
     t.boolean "privacy_lock_inbox", default: false
     t.boolean "privacy_require_user", default: false
     t.boolean "privacy_noindex", default: false
+    t.boolean "privacy_hide_social_graph", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/controllers/answer_controller_spec.rb
+++ b/spec/controllers/answer_controller_spec.rb
@@ -1,10 +1,14 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 describe AnswerController do
-  let(:user) { FactoryBot.create :user,
-                                 otp_module: :disabled,
-                                 otp_secret_key: 'AAAAAAAA'}
-  let(:answer) { FactoryBot.create :answer, user: user }
+  let(:user) do
+    FactoryBot.create :user,
+                      otp_module:     :disabled,
+                      otp_secret_key: "AAAAAAAA"
+  end
+  let(:answer) { FactoryBot.create :answer, user: }
 
   describe "#show" do
     subject { get :show, params: { username: user.screen_name, id: answer.id } }
@@ -22,11 +26,11 @@ describe AnswerController do
     context "user opts out of search indexing" do
       render_views
 
-      before(:each) {
+      before(:each) do
         sign_in user
         user.privacy_noindex = true
         user.save
-      }
+      end
 
       it "renders the answer/show template" do
         subject

--- a/spec/controllers/answer_controller_spec.rb
+++ b/spec/controllers/answer_controller_spec.rb
@@ -18,5 +18,21 @@ describe AnswerController do
         expect(response).to render_template("answer/show")
       end
     end
+
+    context "user opts out of search indexing" do
+      render_views
+
+      before(:each) {
+        sign_in user
+        user.privacy_noindex = true
+        user.save
+      }
+
+      it "renders the answer/show template" do
+        subject
+        expect(assigns(:answer)).to eq(answer)
+        expect(response.body).to include("<meta content='noindex' name='robots'>")
+      end
+    end
   end
 end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -25,11 +25,11 @@ describe UserController, type: :controller do
     context "user opts out of search indexing" do
       render_views
 
-      before(:each) {
+      before(:each) do
         sign_in user
         user.privacy_noindex = true
         user.save
-      }
+      end
 
       it "renders the answer/show template" do
         subject

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -21,6 +21,22 @@ describe UserController, type: :controller do
         expect(response).to render_template("user/show")
       end
     end
+
+    context "user opts out of search indexing" do
+      render_views
+
+      before(:each) {
+        sign_in user
+        user.privacy_noindex = true
+        user.save
+      }
+
+      it "renders the answer/show template" do
+        subject
+        expect(assigns(:user)).to eq(user)
+        expect(response.body).to include("<meta content='noindex' name='robots'>")
+      end
+    end
   end
 
   describe "#followers" do


### PR DESCRIPTION
_More privacy settings!_

Adds `<meta name="robots" content="noindex">` to a profile, answers and questions of a user that enables it.

![image](https://user-images.githubusercontent.com/1774242/202300052-acfb7d30-6185-4372-bd30-a5e868d45221.png)

Closes #542