### PR TITLE
Keep "All new notifications" link accessible

### DIFF
--- a/app/views/navigation/dropdown/_notifications.html.haml
+++ b/app/views/navigation/dropdown/_notifications.html.haml
@@ -7,10 +7,11 @@
       %i.fa.fa-fw.fa-chevron-right
       = t(".all")
   - else
+    %a.dropdown-item.text-center{ href: notifications_path }
+      %i.fa.fa-fw.fa-chevron-right
+      = t(".new")
+
     - notifications.each do |notification|
       .dropdown-item
         = render "notifications/type/#{notification.target.class.name.downcase.split('::').last}", notification: notification
 
-    %a.dropdown-item.text-center{ href: notifications_path }
-      %i.fa.fa-fw.fa-chevron-right
-      = t(".new")

--- a/app/views/navigation/dropdown/_notifications.html.haml
+++ b/app/views/navigation/dropdown/_notifications.html.haml
@@ -1,16 +1,15 @@
 .dropdown-menu.dropdown-menu-right.notification-dropdown{ id: "rs-#{size}-nav-notifications" }
   - if notifications.count.zero?
-    .dropdown-item.text-center.p-2
-      %i.fa.fa-bell-o.notification__bell-icon
-      %p= t(".none")
     %a.dropdown-item.text-center{ href: notifications_path('all') }
       %i.fa.fa-fw.fa-chevron-right
       = t(".all")
+    .dropdown-item.text-center.p-2
+      %i.fa.fa-bell-o.notification__bell-icon
+      %p= t(".none")
   - else
     %a.dropdown-item.text-center{ href: notifications_path }
       %i.fa.fa-fw.fa-chevron-right
       = t(".new")
-
     - notifications.each do |notification|
       .dropdown-item
         = render "notifications/type/#{notification.target.class.name.downcase.split('::').last}", notification: notification


### PR DESCRIPTION
Before: 
When the user gets too many notifications, the link to "All new notifications" gets inaccessible.

After:
Keep the link to "All new notifications" accessible by placing it on the top.