### PR TITLE
inbox_controller: update all inbox entries when requesting turbo stream

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -49,7 +49,11 @@ class InboxController < ApplicationController
     @disabled = true if @inbox.empty?
     respond_to do |format|
       format.html
-      format.turbo_stream { render "show", layout: false, status: :see_other }
+      format.turbo_stream do
+        render "show", layout: false, status: :see_other
+
+        @inbox.update_all(new: false)
+      end
     end
   end
 

--- a/app/views/layouts/inbox.html.haml
+++ b/app/views/layouts/inbox.html.haml
@@ -8,6 +8,6 @@
 = render 'shared/links'
 
 :ruby
-  Inbox.where(id: @inbox.ids).update_all(new: false)
+  @inbox.update_all(new: false)
   provide(:title, generate_title('Inbox'))
   parent_layout 'base'


### PR DESCRIPTION
since there's no layout rendered which updates all inbox entries the inbox entries would still be shown as unread

fixes #827