### PR TITLE
Downgrade bullet to 7.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       activemodel (>= 5.2)
     buftok (0.2.0)
     builder (3.2.4)
-    bullet (7.0.4)
+    bullet (7.0.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     carrierwave (2.1.0)


### PR DESCRIPTION
After upgrading `bullet` Actions are failing on "Run tests" with following test failure:

```
  1) FeedbackHelper#canny_token user signed in should return a proper token
     Failure/Error: JWT.encode(user_data, APP_CONFIG.dig("canny", "sso"))

     OpenSSL::HMACError:
       EVP_PKEY_new_mac_key: malloc failure
     # ./app/helpers/feedback_helper.rb:14:in `canny_token'
     # ./spec/helpers/feedback_helper_spec.rb:28:in `block (4 levels) in <top (required)>'
```

If build passes after this change, this is the reason, if not, then something is wrong with GitHub Actions.