### PR TITLE
Improve notification performance

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
   def notification_count
     return 0 unless user_signed_in?
 
-    count = Notification.for(current_user).where(new: true).pluck(:id).size
+    count = Notification.for(current_user).where(new: true).count
     return nil unless count.positive?
 
     count

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,11 +22,10 @@ module ApplicationHelper
   def notification_count
     return 0 unless user_signed_in?
 
-    count = Notification.for(current_user).where(new: true)
-    return nil if count.nil?
-    return nil unless count.count.positive?
+    count = Notification.for(current_user).where(new: true).pluck(:id).size
+    return nil unless count.positive?
 
-    count.count
+    count
   end
 
   def privileged?(user)

--- a/app/views/navigation/_main.html.haml
+++ b/app/views/navigation/_main.html.haml
@@ -1,4 +1,4 @@
-- notifications = Notification.for(current_user).where(new: true).limit(4)
+- notifications = Notification.for(current_user).where(new: true).includes([:target]).limit(4)
 = render 'navigation/desktop', notifications: notifications
 = render 'navigation/mobile', notifications: notifications
 


### PR DESCRIPTION
Two things:

* `notification_count` produced an N+1 query (present in a lot of Sentry issues), this should be fixed now
* collecting the notifications for the dropdown doesn't use eager loading for the `target`, this is adjusted now