### PR TITLE
Use `has_cached_role?` instead of `has_role?`

### DIFF
--- a/app/controllers/ajax/moderation_controller.rb
+++ b/app/controllers/ajax/moderation_controller.rb
@@ -37,7 +37,7 @@ class Ajax::ModerationController < AjaxController
     unban  = params[:ban] == '0'
     perma  = params[:duration].blank?
 
-    if !unban && target_user.has_role?(:administrator)
+    if !unban && target_user.has_cached_role?(:administrator)
       @response[:status] = :nopriv
       @response[:message] = t(".nopriv")
       return
@@ -88,7 +88,7 @@ class Ajax::ModerationController < AjaxController
     @response[:message] = t(".error")
     return unless %w(moderator admin).include? params[:type].downcase
 
-    unless current_user.has_role?(:administrator)
+    unless current_user.has_cached_role?(:administrator)
       @response[:status] = :nopriv
       @response[:message] = t(".nopriv")
       return

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -6,7 +6,7 @@ class FeedbackController < ApplicationController
   before_action :canny_consent_given?, only: %w[features bugs]
 
   def consent
-    redirect_to feedback_bugs_path if current_user.has_role? :canny_consent
+    redirect_to feedback_bugs_path if current_user.has_cached_role? :canny_consent
   end
 
   def update
@@ -27,6 +27,6 @@ class FeedbackController < ApplicationController
   end
 
   def canny_consent_given?
-    redirect_to feedback_consent_path unless current_user.has_role? :canny_consent
+    redirect_to feedback_consent_path unless current_user.has_cached_role? :canny_consent
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,11 +138,11 @@ class User < ApplicationRecord
 
   # @return [Boolean] is the user a moderator?
   def mod?
-    has_role?(:moderator) || has_role?(:administrator)
+    has_cached_role?(:moderator) || has_cached_role?(:administrator)
   end
 
   def admin?
-    has_role?(:administrator)
+    has_cached_role?(:administrator)
   end
 
   # region stuff used for reporting/moderation

--- a/app/views/inbox/_entry.html.haml
+++ b/app/views/inbox/_entry.html.haml
@@ -14,7 +14,7 @@
             %a{ href: question_path(i.question.user.screen_name, i.question.id) }
               = t(".answers", count: i.question.answer_count)
         .answerbox__question-text= question_markdown i.question.content
-      - if i.question.user_id != current_user.id || current_user.has_role?(:administrator)
+      - if i.question.user_id != current_user.id || current_user.has_cached_role?(:administrator)
         .pull-right
           .btn-group
             %button.btn.btn-default.btn-sm.dropdown-toggle{ data: { toggle: :dropdown }, aria: { expanded: false } }

--- a/app/views/modal/_privileges.html.haml
+++ b/app/views/modal/_privileges.html.haml
@@ -8,7 +8,7 @@
           %span{ aria: { hidden: true } } ×
           %span.sr-only= t("voc.close")
       %ul.list-group
-        - if current_user.has_role?(:administrator)
+        - if current_user.has_cached_role?(:administrator)
           = render "modal/privileges/item", privilege: "moderator", description: t(".role.moderator"), user: user
           = render "modal/privileges/item", privilege: "admin", description: t(".role.admin"), user: user
       .modal-footer

--- a/app/views/modal/privileges/_item.html.haml
+++ b/app/views/modal/privileges/_item.html.haml
@@ -2,7 +2,7 @@
   description ||= ""
   role_mapping = { admin: "administrator" }
   requires_role = %w[admin moderator].include?(privilege)
-  checked = requires_role ? user.has_role?(role_mapping.fetch(privilege, privilege).to_sym) : user.public_send("#{privilege}?")
+  checked = requires_role ? user.has_cached_role?(role_mapping.fetch(privilege, privilege).to_sym) : user.public_send("#{privilege}?")
 %li.list-group-item{ id: "privilege-#{privilege}" }
   .media
     .pull-left

--- a/app/views/navigation/dropdown/_profile.html.haml
+++ b/app/views/navigation/dropdown/_profile.html.haml
@@ -19,7 +19,7 @@
     %a.dropdown-item{ href: moderation_reports_path }
       %i.fa.fa-fw.fa-gavel
       = t(".moderation")
-    - if current_user.has_role?(:administrator)
+    - if current_user.has_cached_role?(:administrator)
       %a.dropdown-item{ href: admin_dashboard_path }
         %i.fa.fa-fw.fa-cogs
         = t(".admin")

--- a/app/views/user/_actions.html.haml
+++ b/app/views/user/_actions.html.haml
@@ -32,7 +32,7 @@
           %a.dropdown-item{ href: '#', data: { target: '#modal-privileges', toggle: :modal } }
             %i.fa.fa-wrench
             = raw t(".privilege", user: user.screen_name)
-          - unless user.has_role?(:administrator)
+          - unless user.has_cached_role?(:administrator)
             %a.dropdown-item{ href: '#', data: { target: '#modal-ban', toggle: :modal } }
               %i.fa.fa-ban
               = t(".ban")
@@ -40,7 +40,7 @@
           %a.dropdown-item{ href: mod_inbox_index_path(user: user.screen_name) }
             %i.fa.fa-inbox
             = t(".view_inbox")
-        - if current_user.has_role? :administrator
+        - if current_user.has_cached_role? :administrator
           %a.dropdown-item{ href: rails_admin_path_for_resource(user), target: '_blank' }
             %i.fa.fa-cogs
             = t("voc.view_in_rails_admin")

--- a/app/views/user/_profile.html.haml
+++ b/app/views/user/_profile.html.haml
@@ -17,12 +17,12 @@
       - if user.following? current_user
         .badge.badge-light
           = t(".badge.follows_you")
-      - if user_signed_in? && current_user.has_role?(:administrator)
-        - if user.has_role?(:administrator)
+      - if user_signed_in? && current_user.has_cached_role?(:administrator)
+        - if user.has_cached_role?(:administrator)
           %span.badge.badge-danger
             %i.fa.fa-fw.fa-flask
             = t(".badge.admin")
-        - if user.has_role?(:moderator)
+        - if user.has_cached_role?(:moderator)
           %span.badge.badge-success
             %i.fa.fa-fw.fa-users
             = t(".badge.moderator")


### PR DESCRIPTION
Just getting rid of more N+1 queries related to the fetching of roles.

I left `has_role?` in some places, mainly tests and the route definition. In case you check for places `has_role?` still remains in.

In case you wonder about following caveat from the [rolify documentation](https://github.com/RolifyCommunity/rolify#cached-roles-to-avoid-n1-issue):

> This method should be used with caution. If you don't preload the roles, the has_cached_role? might return false. In the above example, it would return false for @user.has_cached_role?(:member, Forum), because User.with_role(:admin, Forum) will load only the :admin roles.

[In this issue from 2 years back](https://github.com/RolifyCommunity/rolify/issues/540) it was discussed if it still applies, and apparently since the initial implementation in 2015 and all the Rails updates, the caveat apparently disappeared by itself and `has_cached_role?` seems to be safe.