### PR TITLE
Add support for custom footer links

### DIFF
--- a/app/views/shared/_links.html.haml
+++ b/app/views/shared/_links.html.haml
@@ -10,3 +10,7 @@
   = link_to t(".terms"), terms_path
   ·
   = link_to t(".privacy"), privacy_policy_path
+  - if APP_CONFIG["links"].present?
+    - APP_CONFIG["links"].each do |link|
+      ·
+      = link_to link["text"], link["url"]

--- a/config/justask.yml.example
+++ b/config/justask.yml.example
@@ -35,6 +35,11 @@ about: |
 
   Use this space to describe your Retrospring instance!
 
+# Custom links in the footer
+# links:
+  # - text: "Patreon"
+    # url: "https://patreon.com/retrospring"
+
 # How many items (questions, answers, ...) do you want to show per page?
 items_per_page: 10
 


### PR DESCRIPTION
```yaml
# Custom links in the footer
links:
  - text: "Patreon"
    url: "https://patreon.com/retrospring"
```

![image](https://user-images.githubusercontent.com/1774242/209237949-1f6dce43-cae5-4710-b986-a060865eb376.png)

**Testing:**
* Add `links` to your `justask.yml` and check if they get added to the link list in the footer.

resolves #864 