### PR TITLE
Various frontend fixes

### DIFF
--- a/app/javascript/styles/components/_comments.scss
+++ b/app/javascript/styles/components/_comments.scss
@@ -22,7 +22,6 @@
   }
 
   &__input {
-    z-index: 99;
     padding-right: 2.5rem;
 
     &.is-invalid {
@@ -32,7 +31,7 @@
 
   &__character-count {
     position: absolute;
-    z-index: 100;
+    z-index: 5;
     right: .5rem;
     top: .5rem;
   }

--- a/app/javascript/styles/components/_mobile-nav.scss
+++ b/app/javascript/styles/components/_mobile-nav.scss
@@ -46,6 +46,8 @@
     min-width: unset;
     right: unquote("calc(env(safe-area-inset-right) + 8px)");
     width: unquote("calc(100vw - (8px + env(safe-area-inset-right)) - (8px + env(safe-area-inset-left)))");
+    max-height: calc(100% - 40px - 2rem);
+    overflow-y: scroll;
 
     .dropdown-item {
       padding: 8px;

--- a/app/javascript/styles/components/_question.scss
+++ b/app/javascript/styles/components/_question.scss
@@ -1,8 +1,12 @@
 .question {
   &--fixed {
-    position: fixed;
+    position: absolute;
     width: 100%;
     z-index: 999;
+
+    @include media-breakpoint-up('sm') {
+      position: fixed;
+    }
   }
 
   &--hidden {

--- a/app/javascript/styles/elements/_body.scss
+++ b/app/javascript/styles/elements/_body.scss
@@ -7,7 +7,7 @@ body {
     padding-top: $navbar-height;
   }
   @include media-breakpoint-down('md') {
-    padding-bottom: $navbar-height;
+    padding-bottom: calc($navbar-height + unquote('env(safe-area-inset-bottom, 0)'));
   }
 
   &.not-logged-in {


### PR DESCRIPTION
Guess they had to be fixed someday.

resolves #865 (no overlap)
![image](https://user-images.githubusercontent.com/1774242/209247957-7a8f7e1a-5ff3-4722-8232-450887de2408.png)

resolves #863 (question is not fixed to top on mobile anymore)
![image](https://user-images.githubusercontent.com/1774242/209248107-05c09b66-734d-4391-baae-78f5aa994483.png)

resolves #641
_can't actually showcase this because I can't test on a mobile device, tl;dr we now additionally add `env(safe-area-inset-bottom)` to the bottom padding on mobile_

resolves #561 (notification dropdown now has a max height and is scrollable)
![image](https://user-images.githubusercontent.com/1774242/209248195-a96b54d5-a794-4580-b9f1-e12bde8f7208.png)