### PR TITLE
admin/dashboard: add basic sidekiq stats and warn if sidekiq is not running

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
+require "sidekiq/api"
+
 class Admin::DashboardController < ApplicationController
   before_action :authenticate_user!
 
-  def index; end
+  def index
+    @sidekiq = {
+      processes: Sidekiq::ProcessSet.new,
+      stats:     Sidekiq::Stats.new
+    }
+  end
 end

--- a/app/views/admin/dashboard/_sidekiq.html.haml
+++ b/app/views/admin/dashboard/_sidekiq.html.haml
@@ -1,26 +1,22 @@
 .card
   .card-header
     %a.d-flex{ href: sidekiq_web_path }
-      %strong Sidekiq
+      %strong= t(".title")
       %i.fa.fa-chevron-right.ml-auto.align-self-center
   - unless @sidekiq[:processes].count.positive?
     .card-body.bg-danger.text-light
-      %strong There are no Sidekiq processes running.
-      Background jobs will not be processed.
-      %br
-      To fix this, run
-      %tt RAILS_ENV=#{Rails.env} bundle exec sidekiq
+      = t(".error_html", env: Rails.env)
 
   .list-group
     .list-group-item.d-flex
-      %span Processes
+      %span= t(".processes")
       %span.ml-auto= @sidekiq[:processes].count
     .list-group-item.d-flex
-      %span Enqueued
+      %span= t(".enqueued")
       %span.ml-auto= @sidekiq[:stats].enqueued
     .list-group-item.d-flex
-      %span Retries
+      %span= t(".retries")
       %span.ml-auto= @sidekiq[:stats].retry_size
     .list-group-item.d-flex
-      %span Dead
+      %span= t(".dead")
       %span.ml-auto= @sidekiq[:stats].dead_size

--- a/app/views/admin/dashboard/_sidekiq.html.haml
+++ b/app/views/admin/dashboard/_sidekiq.html.haml
@@ -1,0 +1,26 @@
+.card
+  .card-header
+    %a.d-flex{ href: sidekiq_web_path }
+      %strong Sidekiq
+      %i.fa.fa-chevron-right.ml-auto.align-self-center
+  - unless @sidekiq[:processes].count.positive?
+    .card-body.bg-danger.text-light
+      %strong There are no Sidekiq processes running.
+      Background jobs will not be processed.
+      %br
+      To fix this, run
+      %tt RAILS_ENV=#{Rails.env} bundle exec sidekiq
+
+  .list-group
+    .list-group-item.d-flex
+      %span Processes
+      %span.ml-auto= @sidekiq[:processes].count
+    .list-group-item.d-flex
+      %span Enqueued
+      %span.ml-auto= @sidekiq[:stats].enqueued
+    .list-group-item.d-flex
+      %span Retries
+      %span.ml-auto= @sidekiq[:stats].retry_size
+    .list-group-item.d-flex
+      %span Dead
+      %span.ml-auto= @sidekiq[:stats].dead_size

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -1,5 +1,31 @@
 .card
   .card-body
-    No dashboard content yet!
+    %h2
+      Sidekiq
+
+    %a{ href: sidekiq_web_path } View dashboard
+
+    - unless @sidekiq[:processes].count.positive?
+      .alert.alert-danger{ role: :alert }
+        %strong There are no Sidekiq processes running.
+        Background jobs will not be processed.
+        %br
+        To fix this, run
+        %tt RAILS_ENV=#{Rails.env} bundle exec sidekiq
+
+    %table.table
+      %tbody
+        %tr
+          %th Processes
+          %td= @sidekiq[:processes].count
+        %tr
+          %th Enqueued
+          %td= @sidekiq[:stats].enqueued
+        %tr
+          %th Retries
+          %td= @sidekiq[:stats].retry_size
+        %tr
+          %th Dead
+          %td= @sidekiq[:stats].dead_size
 
 - parent_layout "admin"

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -1,30 +1,5 @@
 .row
   .col-sm-6
-    .card
-      .card-header
-        %a.d-flex{ href: sidekiq_web_path }
-          %strong Sidekiq
-          %i.fa.fa-chevron-right.ml-auto.align-self-center
-      - unless @sidekiq[:processes].count.positive?
-        .card-body.bg-danger.text-light
-          %strong There are no Sidekiq processes running.
-          Background jobs will not be processed.
-          %br
-          To fix this, run
-          %tt RAILS_ENV=#{Rails.env} bundle exec sidekiq
-
-      .list-group
-        .list-group-item.d-flex
-          %span Processes
-          %span.ml-auto= @sidekiq[:processes].count
-        .list-group-item.d-flex
-          %span Enqueued
-          %span.ml-auto= @sidekiq[:stats].enqueued
-        .list-group-item.d-flex
-          %span Retries
-          %span.ml-auto= @sidekiq[:stats].retry_size
-        .list-group-item.d-flex
-          %span Dead
-          %span.ml-auto= @sidekiq[:stats].dead_size
+    = render "admin/dashboard/sidekiq"
 
 - parent_layout "admin"

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -1,31 +1,30 @@
-.card
-  .card-body
-    %h2
-      Sidekiq
+.row
+  .col-sm-6
+    .card
+      .card-header
+        %a.d-flex{ href: sidekiq_web_path }
+          %strong Sidekiq
+          %i.fa.fa-chevron-right.ml-auto.align-self-center
+      - unless @sidekiq[:processes].count.positive?
+        .card-body.bg-danger.text-light
+          %strong There are no Sidekiq processes running.
+          Background jobs will not be processed.
+          %br
+          To fix this, run
+          %tt RAILS_ENV=#{Rails.env} bundle exec sidekiq
 
-    %a{ href: sidekiq_web_path } View dashboard
-
-    - unless @sidekiq[:processes].count.positive?
-      .alert.alert-danger{ role: :alert }
-        %strong There are no Sidekiq processes running.
-        Background jobs will not be processed.
-        %br
-        To fix this, run
-        %tt RAILS_ENV=#{Rails.env} bundle exec sidekiq
-
-    %table.table
-      %tbody
-        %tr
-          %th Processes
-          %td= @sidekiq[:processes].count
-        %tr
-          %th Enqueued
-          %td= @sidekiq[:stats].enqueued
-        %tr
-          %th Retries
-          %td= @sidekiq[:stats].retry_size
-        %tr
-          %th Dead
-          %td= @sidekiq[:stats].dead_size
+      .list-group
+        .list-group-item.d-flex
+          %span Processes
+          %span.ml-auto= @sidekiq[:processes].count
+        .list-group-item.d-flex
+          %span Enqueued
+          %span.ml-auto= @sidekiq[:stats].enqueued
+        .list-group-item.d-flex
+          %span Retries
+          %span.ml-auto= @sidekiq[:stats].retry_size
+        .list-group-item.d-flex
+          %span Dead
+          %span.ml-auto= @sidekiq[:stats].dead_size
 
 - parent_layout "admin"

--- a/app/views/tabs/_admin.html.haml
+++ b/app/views/tabs/_admin.html.haml
@@ -6,5 +6,4 @@
 .card
   .list-group
     = list_group_item t(".rails"), rails_admin_path
-    = list_group_item t(".sidekiq"), sidekiq_web_path
     = list_group_item t(".pghero"), pghero_path

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -88,6 +88,19 @@ en:
         title: "Create Announcement"
       edit:
         title: "Edit Announcement"
+    dashboard:
+      sidekiq:
+        title: "Sidekiq"
+        error_html: |
+          <strong>There are no Sidekiq processes running.</strong>
+          Background jobs will not be processed.
+          <br/>
+          To fix this, run
+          <tt>RAILS_ENV=%{env} bundle exec sidekiq</tt>
+        processes: "Processes"
+        enqueued: "Enqueued"
+        retries: "Retries"
+        dead: "Dead"
   answerbox:
     header:
       anon_hint: :inbox.entry.anon_hint


### PR DESCRIPTION
looks like this:
<img width="1169" alt="Screenshot 2022-12-24 at 22 41 28" src="https://user-images.githubusercontent.com/1809170/209452625-49dc14eb-3f7c-4836-97bc-3362c5a8b9b2.png">

<img width="1193" alt="Screenshot 2022-12-24 at 22 41 43" src="https://user-images.githubusercontent.com/1809170/209452626-d1c40c46-1d38-4ae1-b95e-2cdbacda50cb.png">
