### PR TITLE
Track users in anonymous blocks

### DIFF
--- a/app/controllers/anonymous_block_controller.rb
+++ b/app/controllers/anonymous_block_controller.rb
@@ -12,7 +12,8 @@ class AnonymousBlockController < ApplicationController
     AnonymousBlock.create!(
       user:       params[:global] ? nil : current_user,
       identifier: question.author_identifier,
-      question:
+      question:,
+      target_user: question.user
     )
 
     inbox_id = question.inboxes.first.id

--- a/app/models/anonymous_block.rb
+++ b/app/models/anonymous_block.rb
@@ -5,6 +5,7 @@ require "digest"
 class AnonymousBlock < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :question, optional: true
+  belongs_to :target_user, class_name: "User", optional: true
 
   def self.get_identifier(ip)
     Digest::SHA2.new(512).hexdigest(Rails.application.secret_key_base + ip)

--- a/db/migrate/20221227002012_add_target_user_to_anonymous_blocks.rb
+++ b/db/migrate/20221227002012_add_target_user_to_anonymous_blocks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTargetUserToAnonymousBlocks < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :anonymous_blocks, :target_user, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/migrate/20221227065923_make_question_id_on_anonymous_blocks_nullable.rb
+++ b/db/migrate/20221227065923_make_question_id_on_anonymous_blocks_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeQuestionIdOnAnonymousBlocksNullable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :anonymous_blocks, :question_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -297,8 +297,8 @@ ActiveRecord::Schema.define(version: 2022_12_27_002012) do
     t.integer "otp_module", default: 0, null: false
     t.boolean "privacy_lock_inbox", default: false
     t.boolean "privacy_require_user", default: false
-    t.boolean "privacy_noindex", default: false
     t.boolean "privacy_hide_social_graph", default: false
+    t.boolean "privacy_noindex", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -313,7 +313,5 @@ ActiveRecord::Schema.define(version: 2022_12_27_002012) do
     t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
-  add_foreign_key "anonymous_blocks", "questions"
-  add_foreign_key "anonymous_blocks", "users"
   add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_27_002012) do
+ActiveRecord::Schema.define(version: 2022_12_27_065923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2022_12_27_002012) do
   create_table "anonymous_blocks", force: :cascade do |t|
     t.bigint "user_id"
     t.string "identifier"
-    t.bigint "question_id", null: false
+    t.bigint "question_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "target_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_16_201723) do
+ActiveRecord::Schema.define(version: 2022_12_27_002012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,13 +28,15 @@ ActiveRecord::Schema.define(version: 2022_11_16_201723) do
   end
 
   create_table "anonymous_blocks", force: :cascade do |t|
+    t.bigint "user_id"
     t.string "identifier"
+    t.bigint "question_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id"
-    t.bigint "question_id"
+    t.bigint "target_user_id"
     t.index ["identifier"], name: "index_anonymous_blocks_on_identifier"
     t.index ["question_id"], name: "index_anonymous_blocks_on_question_id"
+    t.index ["target_user_id"], name: "index_anonymous_blocks_on_target_user_id"
     t.index ["user_id"], name: "index_anonymous_blocks_on_user_id"
   end
 

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -83,7 +83,7 @@ module UseCase
       def filtered?(question)
         target_user.mute_rules.any? { |rule| rule.applies_to? question } ||
           (anonymous && AnonymousBlock.where(identifier: question.author_identifier, user_id: [target_user.id, nil]).any?) ||
-          (source_user_id && anonymous && AnonymousBlock.where(target_user_id: [source_user_id, nil], user_id: [target_user.id, nil]).any?)
+          (source_user_id && anonymous && AnonymousBlock.where(target_user_id: [source_user.id, nil], user_id: [target_user.id, nil]).any?)
       end
 
       def source_user

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -82,7 +82,8 @@ module UseCase
 
       def filtered?(question)
         target_user.mute_rules.any? { |rule| rule.applies_to? question } ||
-          (anonymous && AnonymousBlock.where(identifier: question.author_identifier, user_id: [target_user.id, nil]).any?)
+          (anonymous && AnonymousBlock.where(identifier: question.author_identifier, user_id: [target_user.id, nil]).any?) ||
+          (source_user_id && anonymous && AnonymousBlock.where(target_user_id: [source_user_id, nil], user_id: [target_user.id, nil]).any?)
       end
 
       def source_user

--- a/spec/lib/use_case/question/create_spec.rb
+++ b/spec/lib/use_case/question/create_spec.rb
@@ -99,6 +99,20 @@ describe UseCase::Question::Create do
     end
   end
 
+  shared_examples "filters signed in questions" do
+    context "user blocks this anonymized user" do
+      before do
+        target_user.anonymous_blocks.create!(
+          identifier:  "r4nd0m",
+          question_id: FactoryBot.create(:question).id,
+          target_user_id: source_user&.id
+        )
+      end
+
+      it_behaves_like "creates the question", false
+    end
+  end
+
   context "user signed in" do
     let!(:source_user) { FactoryBot.create(:user) }
 
@@ -115,6 +129,7 @@ describe UseCase::Question::Create do
 
           context "recipient allows anonymous questions" do
             it_behaves_like "filters questions"
+            it_behaves_like "filters signed in questions"
             it_behaves_like "creates the question"
             it_behaves_like "validates content"
 

--- a/spec/lib/use_case/question/create_spec.rb
+++ b/spec/lib/use_case/question/create_spec.rb
@@ -9,9 +9,9 @@ describe UseCase::Question::Create do
     UseCase::Question::Create.call(
       source_user_id:    source_user&.id,
       target_user_id:    target_user.id,
-      content:           content,
-      anonymous:         anonymous,
-      author_identifier: author_identifier
+      content:,
+      anonymous:,
+      author_identifier:
     )
   end
 
@@ -103,8 +103,8 @@ describe UseCase::Question::Create do
     context "user blocks this anonymized user" do
       before do
         target_user.anonymous_blocks.create!(
-          identifier:  "r4nd0m",
-          question_id: FactoryBot.create(:question).id,
+          identifier:     "r4nd0m",
+          question_id:    FactoryBot.create(:question).id,
           target_user_id: source_user&.id
         )
       end


### PR DESCRIPTION
Finalizing the anonymous blocks to be as effective as they can be, with the options we give. This Pull Request adds an (optional) `target_user` field to anonymous blocks, which is filled as soon as a question has a user.

In the question create use case we then additionally check not just for a matching author identifier, but also a matching user if the question was sent anonymously.

**Testing:** _(Have fun replicating this locally)_
* Ask someone else a question anonymously, while being logged in (User A)
* As the other user, block that anonymous question (User B)
* _User A should change their IP address_
* User A asks User B another anonymous question
* User B does not have a new question in their inbox

If this case is not able to be replicated, there are tests. Otherwise just make sure that asking questions and blocking as before works the same.

Resolves #522 