### PR TITLE
Silently fail in share worker if user account is suspended

### DIFF
--- a/app/workers/share_worker.rb
+++ b/app/workers/share_worker.rb
@@ -18,6 +18,10 @@ class ShareWorker
   rescue Twitter::Error::DuplicateStatus
     logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the status was already posted."
     return
+  rescue Twitter::Error::Forbidden
+    # User's Twitter account is suspended
+    logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the account is suspended."
+    return
   rescue Twitter::Error::Unauthorized
     # User's Twitter token has expired or been revoked
     # TODO: Notify user if this happens (https://github.com/Retrospring/retrospring/issues/123)

--- a/app/workers/share_worker.rb
+++ b/app/workers/share_worker.rb
@@ -16,19 +16,15 @@ class ShareWorker
   rescue ActiveRecord::RecordNotFound
     logger.info "Tried to post answer ##{answer_id} for user ##{user_id} to #{service.titleize} but the user/answer/service did not exist (likely deleted), will not retry."
     # The question to be posted was deleted
-    nil
   rescue Twitter::Error::DuplicateStatus
     logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the status was already posted."
-    nil
   rescue Twitter::Error::Forbidden
     # User's Twitter account is suspended
     logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the account is suspended."
-    nil
   rescue Twitter::Error::Unauthorized
     # User's Twitter token has expired or been revoked
     # TODO: Notify user if this happens (https://github.com/Retrospring/retrospring/issues/123)
     logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the token has exired or been revoked."
-    nil
   rescue => e
     logger.info "failed to post answer #{answer_id} to #{service} for user #{user_id}: #{e.message}"
     Sentry.capture_exception(e)

--- a/app/workers/share_worker.rb
+++ b/app/workers/share_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ShareWorker
   include Sidekiq::Worker
 
@@ -14,19 +16,19 @@ class ShareWorker
   rescue ActiveRecord::RecordNotFound
     logger.info "Tried to post answer ##{answer_id} for user ##{user_id} to #{service.titleize} but the user/answer/service did not exist (likely deleted), will not retry."
     # The question to be posted was deleted
-    return
+    nil
   rescue Twitter::Error::DuplicateStatus
     logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the status was already posted."
-    return
+    nil
   rescue Twitter::Error::Forbidden
     # User's Twitter account is suspended
     logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the account is suspended."
-    return
+    nil
   rescue Twitter::Error::Unauthorized
     # User's Twitter token has expired or been revoked
     # TODO: Notify user if this happens (https://github.com/Retrospring/retrospring/issues/123)
     logger.info "Tried to post answer ##{answer_id} from user ##{user_id} to Twitter but the token has exired or been revoked."
-    return
+    nil
   rescue => e
     logger.info "failed to post answer #{answer_id} to #{service} for user #{user_id}: #{e.message}"
     Sentry.capture_exception(e)


### PR DESCRIPTION
_Less errors in Sentry! \o/_

(also we shouldn't handle this on our side since people can also be unsuspended, and having people reconnect their accounts everytime this happens would be a pain...even though it's also questionable)