### PR TITLE
fix display conditions of profile questions

### DIFF
--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -98,7 +98,10 @@ describe UserController, type: :controller do
   end
 
   describe "#questions" do
-    let!(:question) { FactoryBot.create(:question, user:, direct: true, author_is_anonymous: false) }
+    let!(:question_anyone) { FactoryBot.create(:question, user:, direct: false, author_is_anonymous: false) }
+    let!(:question_direct) { FactoryBot.create(:question, user:, direct: true, author_is_anonymous: false) }
+    let!(:question_direct_anon) { FactoryBot.create(:question, user:, direct: true, author_is_anonymous: true) }
+
     subject { get :questions, params: { username: user.screen_name } }
 
     it "renders the user/questions template" do
@@ -112,9 +115,11 @@ describe UserController, type: :controller do
         sign_in user
       end
 
-      it "renders all questions" do
+      it "contains all non-anon questions" do
         subject
-        expect(assigns(:questions).size).to eq(1)
+        expect(assigns(:questions)).to include(question_anyone, question_direct)
+        expect(assigns(:questions)).not_to include(question_direct_anon)
+        expect(assigns(:questions).size).to eq(2)
       end
     end
 
@@ -125,9 +130,11 @@ describe UserController, type: :controller do
         sign_in another_user
       end
 
-      it "renders no questions" do
+      it "contains all non-direct non-anon questions" do
         subject
-        expect(assigns(:questions).size).to eq(0)
+        expect(assigns(:questions)).to include(question_anyone)
+        expect(assigns(:questions)).not_to include(question_direct, question_direct_anon)
+        expect(assigns(:questions).size).to eq(1)
       end
     end
 
@@ -139,16 +146,20 @@ describe UserController, type: :controller do
         allow_any_instance_of(UserHelper).to receive(:moderation_view?) { true }
       end
 
-      it "contains all questions" do
+      it "contains all non-anon questions" do
         subject
-        expect(assigns(:questions).size).to eq(1)
+        expect(assigns(:questions)).to include(question_anyone, question_direct)
+        expect(assigns(:questions)).not_to include(question_direct_anon)
+        expect(assigns(:questions).size).to eq(2)
       end
     end
 
     context "when user is not signed in" do
-      it "contains no questions" do
+      it "contains all non-direct non-anon questions" do
         subject
-        expect(assigns(:questions).size).to eq(0)
+        expect(assigns(:questions)).to include(question_anyone)
+        expect(assigns(:questions)).not_to include(question_direct, question_direct_anon)
+        expect(assigns(:questions).size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
fixes #862 

`cursored_questions` will filter on `direct` if it's non-nil, which is always the case when a bool value is passed to it.