### PR TITLE
views/settings: change text of save profile pic button to something less generic

### DIFF
--- a/app/views/settings/profile/edit.html.haml
+++ b/app/views/settings/profile/edit.html.haml
@@ -32,7 +32,7 @@
       - %i[profile_header_x profile_header_y profile_header_w profile_header_h].each do |attrib|
         = f.hidden_field attrib, id: attrib
 
-      = f.primary
+      = f.primary t(".submit_picture")
 .card
   .card-body
     = bootstrap_form_for(current_user.profile, html: { multipart: true }, method: :patch, data: { turbo: false }) do |f|

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -451,6 +451,7 @@ en:
         adjust:
           profile_picture: "Adjust your new profile picture"
           profile_header: "Adjust your new profile header"
+        submit_picture: "Save pictures"
     two_factor_authentication:
       otp_authentication:
         index:


### PR DESCRIPTION
the edit profile page is a bit confusing with the two different buttons with the same text -- better have one say what it's saving.

<img width="1138" alt="Screenshot 2023-01-04 at 15 39 54" src="https://user-images.githubusercontent.com/1809170/210579339-312728d6-736a-47f1-aa66-a5a084e32fec.png">
