### PR TITLE
Don't require an endpoint for unsubscribe

### DIFF
--- a/app/controllers/ajax/web_push_controller.rb
+++ b/app/controllers/ajax/web_push_controller.rb
@@ -42,8 +42,6 @@ class Ajax::WebPushController < AjaxController
   end
 
   def unsubscribe # rubocop:disable Metrics/AbcSize
-    params.require(:endpoint)
-
     removed = if params.key?(:endpoint)
                 current_user.web_push_subscriptions.where("subscription ->> 'endpoint' = ?", params[:endpoint]).destroy_all
               else


### PR DESCRIPTION
This was added by mistake in #914. Unsubscribing without an `endpoint` parameter is supposed to remove all subscriptions.