### PR TITLE
Prevent global anon blocks blocking every anon question with a user

### DIFF
--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -94,7 +94,7 @@ module UseCase
       def filtered?(question)
         target_user.mute_rules.any? { |rule| rule.applies_to? question } ||
           (anonymous && AnonymousBlock.where(identifier: question.author_identifier, user_id: [target_user.id, nil]).any?) ||
-          (source_user_id && anonymous && AnonymousBlock.where(target_user_id: [source_user.id, nil], user_id: [target_user.id, nil]).any?) ||
+          (source_user_id && anonymous && AnonymousBlock.where(target_user_id: source_user.id, user_id: [target_user.id, nil]).any?) ||
           (source_user_id && target_user.muting?(source_user))
       end
 


### PR DESCRIPTION
That should fix the issue of an old-style (pre 2023.0102.0) global anonymous block blocking **every** anonymous question from a user.

Fixes #947 