### PR TITLE
Add collapsibles for answers and questions

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // Font settings
 $lexend-font-path: ".";
 $lexend-weights: 500, 600;
@@ -81,6 +83,16 @@ $spacers: map-merge($rs-spacers, $spacers);
   --input-bg: var(--background);
   --raised-bg: #ffffff;
   --raised-accent: #f7f7f7;
+
+  /**
+   *-rgb values are some of the background colors
+   available as triplets because they are required
+   for background opacity styles
+   */
+
+  --primary-rgb: #{color.red($primary)}, #{color.green($primary)}, #{color.blue($primary)};
+  --raised-bg-rgb: #{color.red(#ffffff)}, #{color.green(#ffffff)}, #{color.blue(#ffffff)};
+  --raised-accent-rgb: #{color.red(#f7f7f7)}, #{color.green(#f7f7f7)}, #{color.blue(#f7f7f7)};
 
   /**
    NOTE for all *-text variables

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -103,6 +103,7 @@ $unicodeRangeValues in Lexend.$unicodeMap {
 "components/answerbox",
 "components/avatars",
 "components/buttons",
+"components/collapse",
 "components/comments",
 "components/container",
 "components/entry",

--- a/app/assets/stylesheets/components/_answerbox.scss
+++ b/app/assets/stylesheets/components/_answerbox.scss
@@ -16,6 +16,11 @@
     overflow: visible;
   }
 
+  &__question-body,
+  &__answer-body {
+    position: relative;
+  }
+
   &__answer-text {
     margin-bottom: map.get($spacers, 3);
   }

--- a/app/assets/stylesheets/components/_collapse.scss
+++ b/app/assets/stylesheets/components/_collapse.scss
@@ -1,0 +1,94 @@
+@use "sass:map";
+
+.collapsed {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  &.answerbox__answer-text {
+    -webkit-line-clamp: 12;
+
+    @include media-breakpoint-up('sm') {
+      -webkit-line-clamp: 7;
+    }
+  }
+
+  &.answerbox__question-text {
+    -webkit-line-clamp: 10;
+
+    @include media-breakpoint-up('sm') {
+      -webkit-line-clamp: 5;
+    }
+  }
+}
+
+.collapser {
+  $this: &;
+
+  display: flex;
+  position: sticky;
+  justify-content: center;
+  width: 100%;
+  padding: map.get($spacers, 2);
+  bottom: calc($nav-link-height + 10px);
+  z-index: 0;
+
+  @include media-breakpoint-up('sm') {
+    bottom: 10px;
+  }
+
+  & .collapsed-text {
+    display: none;
+  }
+
+  & .shown-text {
+    display: inline-block;
+  }
+
+  .collapsed ~ & {
+    position: absolute;
+    bottom: 0;
+
+    &:before {
+      content: "";
+    }
+
+    & .collapsed-text {
+      display: inline-block;
+    }
+
+    & .shown-text {
+      display: none;
+    }
+  }
+
+  &:before {
+    position: absolute;
+    background: linear-gradient(0deg, rgba(var(--gradient-base),1) 0%, rgba(var(--gradient-base),0) 100%);
+    width: 100%;
+    height: 100%;
+  }
+
+  .btn {
+    @extend .btn-primary;
+    z-index: 1;
+  }
+}
+
+.inbox-entry--new .collapser .btn {
+  @extend .btn-light;
+}
+
+.inbox-entry .card-header .collapser,
+.answerbox .card-header .collapser {
+  --gradient-base: var(--raised-accent-rgb);
+}
+
+.question--fixed .card-body .collapser,
+.answerbox .card-body .collapser {
+  --gradient-base: var(--raised-bg-rgb);
+}
+
+.inbox-entry--new .card-header .collapser {
+  --gradient-base: var(--primary-rgb);
+}

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -36,12 +36,8 @@ module ThemeHelper
     theme.attributes.each do |k, v|
       next unless ATTRIBUTE_MAP.key?(k)
 
-      if ATTRIBUTE_MAP[k].is_a?(Array)
-        ATTRIBUTE_MAP[k].each do |var|
-          body += "\t--#{var}: #{get_color_for_key(var, v)};\n"
-        end
-      else
-        body += "\t--#{ATTRIBUTE_MAP[k]}: #{get_color_for_key(ATTRIBUTE_MAP[k], v)};\n"
+      Array(ATTRIBUTE_MAP[k]).each do |var|
+        body += "\t--#{var}: #{get_color_for_key(var, v)};\n"
       end
     end
     body += "\t--turbolinks-progress-color: ##{lighten(theme.primary_color)}\n}"

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -2,7 +2,7 @@
 
 module ThemeHelper
   ATTRIBUTE_MAP = {
-    "primary_color"     => "primary",
+    "primary_color"     => %w[primary primary-rgb],
     "primary_text"      => "primary-text",
     "danger_color"      => "danger",
     "danger_text"       => "danger-text",
@@ -16,8 +16,8 @@ module ThemeHelper
     "dark_text"         => "dark-text",
     "light_color"       => "light",
     "light_text"        => "light-text",
-    "raised_background" => "raised-bg",
-    "raised_accent"     => "raised-accent",
+    "raised_background" => %w[raised-bg raised-bg-rgb],
+    "raised_accent"     => %w[raised-accent raised-accent-rgb],
     "background_color"  => "background",
     "body_text"         => "body-text",
     "input_color"       => "input-bg",
@@ -36,18 +36,27 @@ module ThemeHelper
     theme.attributes.each do |k, v|
       next unless ATTRIBUTE_MAP.key?(k)
 
-      if k.include?("text") || k.include?("placeholder")
-        hex = get_hex_color_from_theme_value(v)
-        body += "\t--#{ATTRIBUTE_MAP[k]}: #{get_decimal_triplet_from_hex(hex)};\n"
+      if ATTRIBUTE_MAP[k].is_a?(Array)
+        ATTRIBUTE_MAP[k].each do |var|
+          body += "\t--#{var}: #{get_color_for_key(var, v)};\n"
+        end
       else
-        body += "\t--#{ATTRIBUTE_MAP[k]}: ##{get_hex_color_from_theme_value(v)};\n"
+        body += "\t--#{ATTRIBUTE_MAP[k]}: #{get_color_for_key(ATTRIBUTE_MAP[k], v)};\n"
       end
     end
-    body += "\t--turbolinks-progress-color: ##{lighten(theme.primary_color)}\n"
-
-    body += "}"
+    body += "\t--turbolinks-progress-color: ##{lighten(theme.primary_color)}\n}"
 
     content_tag(:style, body)
+  end
+
+  def get_color_for_key(key, color)
+    hex = get_hex_color_from_theme_value(color)
+
+    if key.include?("text") || key.include?("placeholder") || key.include?("rgb")
+      get_decimal_triplet_from_hex(hex)
+    else
+      "##{hex}"
+    end
   end
 
   def theme_color

--- a/app/javascript/retrospring/controllers/collapse_controller.ts
+++ b/app/javascript/retrospring/controllers/collapse_controller.ts
@@ -1,0 +1,16 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static targets = ['action', 'content'];
+
+  declare readonly contentTarget: HTMLElement;
+  declare readonly actionTarget: HTMLElement;
+
+  connect(): void {
+    this.actionTarget.addEventListener('click', this.update.bind(this));
+  }
+
+  update(): void {
+    this.contentTarget.classList.toggle('collapsed');
+  }
+}

--- a/app/javascript/retrospring/initializers/stimulus.ts
+++ b/app/javascript/retrospring/initializers/stimulus.ts
@@ -4,6 +4,7 @@ import AutofocusController from "retrospring/controllers/autofocus_controller";
 import CharacterCountController from "retrospring/controllers/character_count_controller";
 import CharacterCountWarningController from "retrospring/controllers/character_count_warning_controller";
 import FormatPopupController from "retrospring/controllers/format_popup_controller";
+import CollapseController from "retrospring/controllers/collapse_controller";
 
 /**
  * This module sets up Stimulus and our controllers
@@ -18,5 +19,6 @@ export default function (): void {
   window['Stimulus'].register('autofocus', AutofocusController);
   window['Stimulus'].register('character-count', CharacterCountController);
   window['Stimulus'].register('character-count-warning', CharacterCountWarningController);
+  window['Stimulus'].register('collapse', CollapseController);
   window['Stimulus'].register('format-popup', FormatPopupController);
 }

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -14,6 +14,8 @@ class Answer < ApplicationRecord
   validates :question_id, uniqueness: { scope: :user_id }
   # rubocop:enable Rails/UniqueValidationWithoutIndex
 
+  SHORT_ANSWER_MAX_LENGTH = 640
+
   # rubocop:disable Rails/SkipsModelValidations
   after_create do
     Inbox.where(user: self.user, question: self.question).destroy_all
@@ -52,4 +54,6 @@ class Answer < ApplicationRecord
   def notification_type(*_args)
     Notification::QuestionAnswered
   end
+
+  def long? = content.length > SHORT_ANSWER_MAX_LENGTH
 end

--- a/app/views/answerbox/_header.html.haml
+++ b/app/views/answerbox/_header.html.haml
@@ -14,9 +14,9 @@
           %a{ href: question_path(a.question.user.screen_name, a.question.id) }
             = t(".answers", count: a.question.answer_count)
       .answerbox__question-body{ data: { controller: "collapse" } }
-        .answerbox__question-text{ class: a.question.long? ? "collapsed" : "", data: { collapse_target: "content" } }
+        .answerbox__question-text{ class: a.question.long? && !display_all ? "collapsed" : "", data: { collapse_target: "content" } }
           = question_markdown a.question.content
-        - if a.question.long?
+        - if a.question.long? && !display_all
           = render "shared/collapse", type: "question"
     - if user_signed_in?
       .flex-shrink-0.ms-auto

--- a/app/views/answerbox/_header.html.haml
+++ b/app/views/answerbox/_header.html.haml
@@ -13,8 +13,11 @@
           ·
           %a{ href: question_path(a.question.user.screen_name, a.question.id) }
             = t(".answers", count: a.question.answer_count)
-      .answerbox__question-text
-        = question_markdown a.question.content
+      .answerbox__question-body{ data: { controller: "collapse" } }
+        .answerbox__question-text{ class: a.question.long? ? "collapsed" : "", data: { collapse_target: "content" } }
+          = question_markdown a.question.content
+        - if a.question.long?
+          = render "shared/collapse", type: "question"
     - if user_signed_in?
       .flex-shrink-0.ms-auto
         .btn-group

--- a/app/views/application/_answerbox.html.haml
+++ b/app/views/application/_answerbox.html.haml
@@ -1,12 +1,12 @@
 - display_all ||= nil
 .card.answerbox{ data: { id: a.id, q_id: a.question.id } }
   - if @question.nil?
-    = render "answerbox/header", a: a
+    = render "answerbox/header", a: a, display_all: display_all
   .card-body
     .answerbox__answer-body{ data: { controller: "collapse" } }
-      .answerbox__answer-text{ class: a.long? ? "collapsed" : "", data: { collapse_target: "content" } }
+      .answerbox__answer-text{ class: a.long? && !display_all ? "collapsed" : "", data: { collapse_target: "content" } }
         = markdown a.content
-      - if a.long?
+      - if a.long? && !display_all
         = render "shared/collapse", type: "answer"
     - if @user.nil?
       .row

--- a/app/views/application/_answerbox.html.haml
+++ b/app/views/application/_answerbox.html.haml
@@ -3,16 +3,11 @@
   - if @question.nil?
     = render "answerbox/header", a: a
   .card-body
-    - if display_all.nil?
-      .answerbox__answer-text
-        = markdown a.content.truncate(640, omission: " [...]", separator: /\s/)
-        - if a.content.length > 640
-          %p
-            %a.btn.btn-primary{ href: answer_path(a.user.screen_name, a.id) }
-              = t(".read")
-    - else
-      .answerbox__answer-text
+    .answerbox__answer-body{ data: { controller: "collapse" } }
+      .answerbox__answer-text{ class: a.long? ? "collapsed" : "", data: { collapse_target: "content" } }
         = markdown a.content
+      - if a.long?
+        = render "shared/collapse", type: "answer"
     - if @user.nil?
       .row
         .col-sm-6.text-start.text-muted

--- a/app/views/inbox/_entry.html.haml
+++ b/app/views/inbox/_entry.html.haml
@@ -14,7 +14,11 @@
             ·
             %a{ href: question_path(i.question.user.screen_name, i.question.id) }
               = t(".answers", count: i.question.answer_count)
-        .answerbox__question-text= question_markdown i.question.content
+        .answerbox__question-body{ data: { controller: "collapse" } }
+          .answerbox__question-text{ class: i.question.long? ? "collapsed" : "", data: { collapse_target: "content" } }
+            = question_markdown i.question.content
+          - if i.question.long?
+            = render "shared/collapse", type: "question"
       - if i.question.user_id != current_user.id || current_user.has_cached_role?(:administrator)
         .flex-shrink-0.ms-auto
           .btn-group

--- a/app/views/question/_question.html.haml
+++ b/app/views/question/_question.html.haml
@@ -13,7 +13,11 @@
               = user_screen_name question.user, author_identifier: identifier, url: false
             - else
               = t("answerbox.header.asked_html", user: user_screen_name(question.user, author_identifier: identifier), time: time_tooltip(question))
-          .answerbox__question-text= question_markdown question.content
+          .answerbox__question-body{ data: { controller: "collapse" } }
+            .answerbox__question-text{ class: question.long? ? "collapsed" : "", data: { collapse_target: "content" } }
+              = question_markdown question.content
+            - if question.long?
+              = render "shared/collapse", type: "question"
         - if user_signed_in?
           .flex-shrink-0.ms-auto
             .btn-group

--- a/app/views/shared/_collapse.html.haml
+++ b/app/views/shared/_collapse.html.haml
@@ -1,0 +1,4 @@
+.collapser
+  %button.btn.btn-primary.btn-sm.shadow{ data: { collapse_target: "action" } }
+    %span.shown-text= t(".#{type}.hide")
+    %span.collapsed-text= t(".#{type}.show")

--- a/app/views/shared/_collapse.html.haml
+++ b/app/views/shared/_collapse.html.haml
@@ -1,4 +1,4 @@
-.collapser
+.collapser{ aria: { hidden: "true" } }
   %button.btn.btn-primary.btn-sm.shadow{ data: { collapse_target: "action" } }
     %span.shown-text= t(".#{type}.hide")
     %span.collapsed-text= t(".#{type}.show")

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -551,6 +551,13 @@ en:
       unsubscribe_all: "Disable on all devices"
       description: "Here you can set up or disable push notifications for new questions in your inbox."
   shared:
+    collapse:
+      answer:
+        show: "Show full answer"
+        hide: "Hide full answer"
+      question:
+        show: "Show full question"
+        hide: "Hide full question"
     formatting:
       body_html: |
         <p>%{app_name} uses <b>Markdown</b> for formatting</p>

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -242,4 +242,22 @@ describe ThemeHelper, :type => :helper do
       end
     end
   end
+
+  describe "#get_color_for_key" do
+    context "any key and value are supplied" do
+      subject { helper.get_color_for_key("primary", 6174129) }
+
+      it "returns a hex color code" do
+        expect(subject).to eq("#5e35b1")
+      end
+    end
+
+    context "a text key is supplied" do
+      subject { helper.get_color_for_key("primary-text", 6174129) }
+
+      it "returns RGB triplets" do
+        expect(subject).to eq("94, 53, 177")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Desktop:
![image](https://user-images.githubusercontent.com/1774242/212141691-396a93b3-1490-4913-9253-b1bb85cfd687.png)

Mobile:
![image](https://user-images.githubusercontent.com/1774242/212141834-61598f9f-522e-4a5c-ac76-7472c11b6c31.png)

On detail pages the content is always fully shown.

Test with your themes and report any issues. Also check with long new questions if the gradient works for you.