### PR TITLE
Remove dropup notification menu from mobile

### DIFF
--- a/app/views/navigation/_mobile.html.haml
+++ b/app/views/navigation/_mobile.html.haml
@@ -8,12 +8,8 @@
         icon: 'inbox', icon_only: true
       - if APP_CONFIG.dig(:features, :discover, :enabled) || current_user.mod?
         = nav_entry t("navigation.discover"), discover_path, icon: 'compass', icon_only: true
-      %li.nav-item
-        %a.nav-link{ href: '#', data: { bs_toggle: 'dropdown', bs_target: '#rs-mobile-nav-notifications' }, aria: { controls: 'rs-mobile-nav-notifications', expanded: 'false' } }
-          %i.fa{ class: "fa-#{notifications_icon}" }
-          %span.visually-hidden= t("navigation.notifications")
-          %span.badge.badge-pill.badge-primary= notification_count
-        = render 'navigation/dropdown/notifications', notifications: notifications, size: "mobile"
+      = nav_entry t("navigation.notifications"), notifications_path("all"), icon: notifications_icon,
+        badge: notification_count, badge_color: "primary", icon_only: true
       %li.nav-item.profile--image-dropdown
         %a.nav-link{ href: '#', data: { bs_toggle: 'dropdown', bs_target: '#rs-mobile-nav-profile' }, aria: { controls: 'rs-mobile-nav-profile', expanded: 'false' } }
           %img.avatar-md.d-inline{ src: current_user.profile_picture.url(:small) }


### PR DESCRIPTION
Fixes #956 

> Case in point: considering that it is full-height now it doesn't actually matter if we open the notifications page, it's less buggy that way and through Turbo the navigation back should be quite fast anyway.