### PR TITLE
Fix 'Buffer is not defined' on push enable

### DIFF
--- a/app/javascript/retrospring/features/webpush/enable.ts
+++ b/app/javascript/retrospring/features/webpush/enable.ts
@@ -1,6 +1,7 @@
 import { get, post } from '@rails/request.js';
 import I18n from "retrospring/i18n";
 import { showNotification } from "utilities/notifications";
+import { Buffer } from "buffer";
 
 export function enableHandler (event: Event): void {
   event.preventDefault();

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@popperjs/core": "^2.11",
     "@rails/request.js": "^0.0.8",
     "bootstrap": "^5.2",
+    "buffer": "^6.0.3",
     "cheet.js": "^0.3.3",
     "croppr": "^2.3.1",
     "i18n-js": "^4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,6 +482,11 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 bignumber.js@*:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
@@ -511,6 +516,14 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -1335,6 +1348,11 @@ i18n-js@^4.0:
   dependencies:
     bignumber.js "*"
     lodash "*"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"


### PR DESCRIPTION
I have no idea how this doesn't fail the build but ESBuild doesn't expose this as it's from the Node.js stdlib