### PR TITLE
Fix unprivileged comment actions being visible

### DIFF
--- a/app/views/actions/_comment.html.haml
+++ b/app/views/actions/_comment.html.haml
@@ -6,11 +6,11 @@
     %a.dropdown-item.text-danger{ href: "#", data: { action: "ab-comment-destroy", c_id: comment.id } }
       %i.fa.fa-fw.fa-trash-o
       = t("voc.delete")
-  - unless comment.user == current_user
+  - if user_signed_in? && comment.user != current_user
     %a.dropdown-item{ href: "#", data: { action: "ab-comment-report", c_id: comment.id } }
       %i.fa.fa-fw.fa-exclamation-triangle
       = t("voc.report")
-  - if current_user.admin?
+  - if user_signed_in? && current_user&.admin?
     %a.dropdown-item{ href: rails_admin_path_for_resource(comment), target: "_blank" }
       %i.fa.fa-fw.fa-gears
       = t("voc.view_in_rails_admin")


### PR DESCRIPTION
- Fixes an error when viewing answers containing comments while not logged in
- Hides the report option while not logged in

I couldn't replicate this locally but this resolves [RETROSPRING-E3](https://sentry.io/share/issue/0b62e3a302964d608c64c1d498322aa8/) which was reported via a question to [@retrospring](https://retrospring.net/@retrospring)