### PR TITLE
Fix author-searched deletion in inbox not working

### DIFF
--- a/app/javascript/retrospring/features/inbox/author.ts
+++ b/app/javascript/retrospring/features/inbox/author.ts
@@ -1,6 +1,0 @@
-export function authorSearchHandler(event: Event): void {
-  event.preventDefault();
-
-  const author = document.querySelector<HTMLInputElement>('#author')?.value;
-  window.location.href = `/inbox/${encodeURIComponent(author)}`;
-}

--- a/app/javascript/retrospring/features/inbox/delete.ts
+++ b/app/javascript/retrospring/features/inbox/delete.ts
@@ -62,6 +62,7 @@ export function deleteAllQuestionsHandler(event: Event): void {
 export function deleteAllAuthorQuestionsHandler(event: Event): void {
   const button = event.target as Element;
   const count = button.getAttribute('data-ib-count');
+  const urlSearchParams = new URLSearchParams(window.location.search);
 
   swal({
     title: I18n.translate('frontend.inbox.confirm_all.title', { count: count }),
@@ -75,7 +76,7 @@ export function deleteAllAuthorQuestionsHandler(event: Event): void {
   }, (returnValue) => {
     if (returnValue === null) return false;
 
-    post(`/ajax/delete_all_inbox/${location.pathname.split('/')[2]}`)
+    post(`/ajax/delete_all_inbox/${urlSearchParams.get('author')}`)
       .then(async response => {
         const data = await response.json;
 

--- a/app/javascript/retrospring/features/inbox/index.ts
+++ b/app/javascript/retrospring/features/inbox/index.ts
@@ -6,8 +6,7 @@ import { deleteAllAuthorQuestionsHandler, deleteAllQuestionsHandler } from './de
 export default (): void => {
   registerEvents([
     { type: 'click', target: '#ib-delete-all', handler: deleteAllQuestionsHandler, global: true },
-    { type: 'click', target: '#ib-delete-all-author', handler: deleteAllAuthorQuestionsHandler, global: true },
-    { type: 'submit', target: '#author-form', handler: authorSearchHandler, global: true }
+    { type: 'click', target: '#ib-delete-all-author', handler: deleteAllAuthorQuestionsHandler, global: true }
   ]);
 
   registerInboxEntryEvents();


### PR DESCRIPTION
This was reported in Canny.

Since we switched the parameter for the author search from `/inbox/username` to `/inbox?author=username` this stopped working.

Also used the opportunity to remove the JS to search for the user, it's not required anymore.