### PR TITLE
Pre-load own mute relationships in follow lists

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -21,7 +21,7 @@ class UserController < ApplicationController
     @users = @relationships.map(&:source)
     own_relationships = find_own_relationships
     locals = {
-      type:           :friend,
+      type:           :follower,
       own_followings: own_relationships[Relationships::Follow],
       own_blocks:     own_relationships[Relationships::Block],
       own_mutes:      own_relationships[Relationships::Mute]

--- a/app/views/shared/_userbox.html.haml
+++ b/app/views/shared/_userbox.html.haml
@@ -9,4 +9,4 @@
           = user.profile.display_name
       .profile__screen-name
         = user.screen_name
-    = render "user/actions", user:, type:, own_followings:, own_blocks:
+    = render "user/actions", user:, type:, own_followings:, own_blocks:, own_mutes:

--- a/app/views/user/_actions.html.haml
+++ b/app/views/user/_actions.html.haml
@@ -2,6 +2,7 @@
   - type ||= :nil
   - own_followings ||= nil
   - own_blocks ||= nil
+  - own_mutes ||= nil
   - if user_signed_in? && user == current_user
     .d-grid
       %a.btn.btn-dark{ href: settings_profile_path } Edit profile
@@ -29,7 +30,7 @@
             %a.dropdown-item{ href: '#', data: { action: :block, target: user.screen_name } }
               %i.fa.fa-minus-circle.fa-fw
               %span.pe-none= t("voc.block")
-          - if current_user.muting?(user)
+          - if own_mutes&.include?(user.id) || current_user.muting?(user)
             %a.dropdown-item{ href: '#', data: { action: :unmute, target: user.screen_name } }
               %i.fa.fa-volume-off.fa-fw
               %span.pe-none= t("voc.unmute")

--- a/app/views/user/show_follow.html.haml
+++ b/app/views/user/show_follow.html.haml
@@ -1,7 +1,7 @@
 .row.row-cols-1.row-cols-sm-2.row-cols-md-3#users
   - @users.each do |user|
     .col.pb-3
-      = render "shared/userbox", user:, type:, own_followings:, own_blocks:
+      = render "shared/userbox", user:, type:, own_followings:, own_blocks:, own_mutes:
 
 - if @more_data_available
   .d-flex.justify-content-center.justify-content-sm-start#paginator

--- a/app/views/user/show_follow.turbo_stream.haml
+++ b/app/views/user/show_follow.turbo_stream.haml
@@ -1,7 +1,7 @@
 = turbo_stream.append "users" do
   - @users.each do |user|
     .col.pb-3
-      = render "shared/userbox", user:, type:, own_followings:, own_blocks:
+      = render "shared/userbox", user:, type:, own_followings:, own_blocks:, own_mutes:
 
 = turbo_stream.update "paginator" do
   - if @more_data_available


### PR DESCRIPTION
Turns out we were still getting 𝑛+1s here as mutes got missed.