### PR TITLE
Eagerly load services in action to prevent n+1 query

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -18,7 +18,7 @@ class InboxController < ApplicationController
 
     @delete_id = find_delete_id
     @disabled = true if @inbox.empty?
-    services = current_user.services
+    services = current_user.services.to_a
 
     respond_to do |format|
       format.html { render "show", locals: { services: } }


### PR DESCRIPTION
Just running

```ruby
services = current_user.services
```

didn't actually run the query and save the services into `services`, so `services.count.positive?` still created a `SELECT COUNT` query for each inbox entry.
