### PR TITLE
add Containerfile to be used for running Retrospring

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,77 @@
+# Container image for a production Retrospring setup
+
+FROM registry.opensuse.org/opensuse/leap:15.4
+
+ARG RETROSPRING_VERSION=2023.0131.1
+ARG RUBY_VERSION=3.1.2
+ARG RUBY_INSTALL_VERSION=0.9.0
+ARG BUNDLER_VERSION=2.3.18
+
+ENV RAILS_ENV=production
+
+# update and install dependencies
+RUN zypper up -y \
+ && zypper in -y \
+      # build dependencies (ruby-install)
+      automake         \
+      gcc              \
+      gdbm-devel       \
+      gzip             \
+      libffi-devel     \
+      libopenssl-devel \
+      libyaml-devel    \
+      make             \
+      ncurses-devel    \
+      readline-devel   \
+      tar              \
+      xz               \
+      zlib-devel       \
+      # build dependencies (app)
+      gcc-c++          \
+      git              \
+      libidn-devel     \
+      nodejs14         \
+      npm14            \
+      postgresql-devel \
+      # runtime dependencies
+      ImageMagick      \
+ # cleanup repos
+ && zypper clean -a \
+ # install yarn as another build dependency
+ && npm install -g yarn
+
+# install Ruby via ruby-install
+RUN curl -Lo ruby-install-${RUBY_INSTALL_VERSION}.tar.gz https://github.com/postmodern/ruby-install/archive/v${RUBY_INSTALL_VERSION}.tar.gz \
+ && tar xvf ruby-install-${RUBY_INSTALL_VERSION}.tar.gz \
+ && (cd ruby-install-${RUBY_INSTALL_VERSION} && make install) \
+ && rm -rf ruby-install-${RUBY_INSTALL_VERSION} ruby-install-${RUBY_INSTALL_VERSION}.tar.gz \
+ && ruby-install --no-install-deps --cleanup --system --jobs=$(nproc) ruby ${RUBY_VERSION} -- --disable-install-rdoc \
+ && gem install bundler:${BUNDLER_VERSION}
+
+# create user and dirs to run retrospring in
+RUN useradd -m justask \
+ && install -o justask -g users -m 0755 -d /opt/retrospring/app    \
+ && install -o justask -g users -m 0755 -d /opt/retrospring/bundle
+
+WORKDIR /opt/retrospring/app
+USER justask:users
+
+# install the app
+RUN curl -L https://github.com/Retrospring/retrospring/archive/refs/tags/${RETROSPRING_VERSION}.tar.gz | tar xz --strip-components=1
+
+RUN bundle config set without 'development test'     \
+ && bundle config set path '/opt/retrospring/bundle' \
+ && bundle install --jobs=$(nproc)                   \
+ && yarn install --frozen-lockfile
+
+# temporarily set a SECRET_KEY_BASE and copy config files so rake tasks can run
+ENV SECRET_KEY_BASE=secret_for_build
+RUN cp config/justask.yml.example config/justask.yml    \
+ && cp config/database.yml.postgres config/database.yml \
+ && bundle exec rails locale:generate                   \
+ && bundle exec i18n export                             \
+ && bundle exec rails assets:precompile                 \
+ && rm config/justask.yml config/database.yml
+ENV SECRET_KEY_BASE=
+
+EXPOSE 3000


### PR DESCRIPTION
This adds a `Containerfile` that will eventually be used to run the web app and workers.  **This is not intended for development**!

It is built from an archive .tar.gz, so we can add another GitHub Actions job that builds it whenever a new tag is pushed.

Using `podman` a new image for a new version (including changes like ruby and bundler versions) can be built automatically like this:

```shell
RETROSPRING_VERSION=2023.0131.1
podman build --build-arg RUBY_VERSION=$(cat .ruby-version) --build-arg BUNDLER_VERSION=$(egrep -A1 "^BUNDLED WITH" Gemfile.lock | tr -d '\n' | awk '{ print $3; }') --build-arg RETROSPRING_VERSION=${RETROSPRING_VERSION} --tag retrospring/retrospring:${RETROSPRING_VERSION} .
```

In the first step we still need to mount the config files into the container, like so:

```shell
podman run --rm -it -v /home/justask/database.yml:/opt/retrospring/app/config/database.yml -v /home/justask/sidekiq.yml:/opt/retrospring/app/config/sidekiq.yml -v /home/justask/justask.yml:/opt/retrospring/app/config/justask.yml -v /home/justask/devise.rb:/opt/retrospring/app/config/initializers/devise.rb -e SECRET_KEY_BASE=seeeecret -e RAILS_LOG_TO_STDOUT=true retrospring/retrospring:2023.0131.1 bundle exec sidekiq
```

Eventually some of the config should be done through ENV variables, probably.