### PR TITLE
allow log level, site_name, and hostname to be configured via ENV

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,3 +131,6 @@ Style/Encoding:
 
 Style/EndlessMethod:
   EnforcedStyle: allow_always
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma

--- a/Containerfile
+++ b/Containerfile
@@ -65,14 +65,13 @@ RUN bundle config set without 'development test'     \
  && yarn install --frozen-lockfile
 
 # temporarily set a SECRET_KEY_BASE and copy config files so rake tasks can run
-ENV SECRET_KEY_BASE=secret_for_build
+ARG SECRET_KEY_BASE=secret_for_build
 RUN cp config/justask.yml.example config/justask.yml    \
  && cp config/database.yml.postgres config/database.yml \
  && bundle exec rails locale:generate                   \
  && bundle exec i18n export                             \
  && bundle exec rails assets:precompile                 \
  && rm config/justask.yml config/database.yml
-ENV SECRET_KEY_BASE=
 
 # set some defaults
 ENV RAILS_LOG_TO_STDOUT=true

--- a/Containerfile
+++ b/Containerfile
@@ -74,4 +74,7 @@ RUN cp config/justask.yml.example config/justask.yml    \
  && rm config/justask.yml config/database.yml
 ENV SECRET_KEY_BASE=
 
+# set some defaults
+ENV RAILS_LOG_TO_STDOUT=true
+
 EXPOSE 3000

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,6 +51,10 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = ENV.fetch("LOG_LEVEL") { "debug" }.to_sym
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -73,6 +77,6 @@ Rails.application.configure do
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
 
-# For better_errors to work inside Docker we need 
+# For better_errors to work inside Docker we need
 # to allow 0.0.0.0 as an IP in development context
 BetterErrors::Middleware.allow_ip! "0.0.0.0/0"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV.fetch("LOG_LEVEL") { "info" }.to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,10 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = ENV.fetch("LOG_LEVEL") { "debug" }.to_sym
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/10_config.rb
+++ b/config/initializers/10_config.rb
@@ -1,5 +1,23 @@
+# frozen_string_literal: true
+
 # Auxiliary config
-APP_CONFIG = YAML.load_file(Rails.root.join('config', 'justask.yml')).with_indifferent_access
+
+APP_CONFIG = {}.with_indifferent_access
+
+# load yml config if it's present
+justask_yml_path = Rails.root.join("config/justask.yml")
+APP_CONFIG.merge!(YAML.load_file(justask_yml_path)) if File.exist?(justask_yml_path)
+
+# load config from ENV where possible
+env_config = {
+  # The site name, shown everywhere
+  site_name: ENV.fetch("SITE_NAME", nil),
+
+  hostname:  ENV.fetch("HOSTNAME", nil),
+}.compact
+APP_CONFIG.merge!(env_config)
 
 # Update rails config for mail
-Rails.application.config.action_mailer.default_url_options = { host: APP_CONFIG['hostname'] }
+Rails.application.config.action_mailer.default_url_options = {
+  host: APP_CONFIG["hostname"],
+}


### PR DESCRIPTION
made log level configurable via ENV, set it to `:info` by default, and also started to load some `justask.yml` configs from ENV

We do not need to worry about the `database.yml` or even the redis URL -- Rails lets us use `DATABASE_URL=postgres://justask:seeeeecret@db01/justask_production?pool=25` to specify the database to connect to, and we already check `REDIS_URL` in the Sidekiq initialiser.