### PR TITLE
Minify assets in production builds

### DIFF
--- a/lib/tasks/css.rake
+++ b/lib/tasks/css.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :css do
+  desc "Build your CSS bundle"
+  task :build do
+    command = "yarn install && yarn build:css"
+    command += " --style=compressed" if Rails.env.production?
+
+    raise "Ensure yarn is installed and `yarn build:css` runs without errors" unless system command
+  end
+end
+
+Rake::Task["assets:precompile"].enhance(["css:build"])

--- a/lib/tasks/css.rake
+++ b/lib/tasks/css.rake
@@ -2,7 +2,7 @@
 
 namespace :css do
   desc "Build your CSS bundle"
-  task :build do
+  task build: :environment do
     command = "yarn install && yarn build:css"
     command += " --style=compressed" if Rails.env.production?
 

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -2,7 +2,7 @@
 
 namespace :javascript do
   desc "Build your JavaScript bundle"
-  task :build do
+  task build: :environment do
     command = "yarn install && yarn build"
     command += " --minify" if Rails.env.production?
 

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :javascript do
+  desc "Build your JavaScript bundle"
+  task :build do
+    command = "yarn install && yarn build"
+    command += " --minify" if Rails.env.production?
+
+    raise "Ensure yarn is installed and `yarn build` runs without errors" unless system command
+  end
+end
+
+Rake::Task["assets:precompile"].enhance(["javascript:build"])

--- a/spec/integration/css_build_spec.rb
+++ b/spec/integration/css_build_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "support/load_rake_tasks"
+
+describe "test css building" do
+  it "succeeds" do
+    Rake::Task["css:build"].execute
+
+    expect { File.open(Rails.root.join("app/assets/builds/application.css")) }.to_not raise_error
+  end
+end

--- a/spec/integration/css_build_spec.rb
+++ b/spec/integration/css_build_spec.rb
@@ -7,6 +7,6 @@ describe "test css building" do
   it "succeeds" do
     Rake::Task["css:build"].execute
 
-    expect { File.open(Rails.root.join("app/assets/builds/application.css")) }.to_not raise_error
+    expect { Rails.root.join("app/assets/builds/application.css").open }.to_not raise_error
   end
 end

--- a/spec/integration/javascript_build_spec.rb
+++ b/spec/integration/javascript_build_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "support/load_rake_tasks"
+
+describe "test javascript building" do
+  it "succeeds" do
+    Rake::Task["javascript:build"].execute
+
+    expect { File.open(Rails.root.join("app/assets/builds/application.js")) }.to_not raise_error
+  end
+end

--- a/spec/integration/javascript_build_spec.rb
+++ b/spec/integration/javascript_build_spec.rb
@@ -7,6 +7,6 @@ describe "test javascript building" do
   it "succeeds" do
     Rake::Task["javascript:build"].execute
 
-    expect { File.open(Rails.root.join("app/assets/builds/application.js")) }.to_not raise_error
+    expect { Rails.root.join("app/assets/builds/application.js").open }.to_not raise_error
   end
 end


### PR DESCRIPTION
Size comparision from dev -> prod builds:

```
application.css: 465kb  -> 376kb
application.js:  1021kb -> 441kb
```

This is kinda hacky because I enhance the jsbundling/cssbundling rake tasks, which means that building effectively runs twice. The build process is incredibly fast though, so it's a bit of a trade here.