### PR TITLE
Add TurboStreamable concern

### DIFF
--- a/app/controllers/anonymous_block_controller.rb
+++ b/app/controllers/anonymous_block_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class AnonymousBlockController < ApplicationController
+  include TurboStreamable
+
   before_action :authenticate_user!
 
-  def turbo_stream_actions = %i[create destroy]
-
-  include TurboStreamable
+  turbo_stream_actions :create, :destroy
 
   def create
     params.require :question

--- a/app/controllers/anonymous_block_controller.rb
+++ b/app/controllers/anonymous_block_controller.rb
@@ -3,6 +3,10 @@
 class AnonymousBlockController < ApplicationController
   before_action :authenticate_user!
 
+  def turbo_stream_actions = %i[create destroy]
+
+  include TurboStreamable
+
   def create
     params.require :question
 
@@ -21,8 +25,10 @@ class AnonymousBlockController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.remove("inbox_#{inbox_id}")
+        render turbo_stream: [
           inbox_id ? turbo_stream.remove("inbox_#{inbox_id}") : nil,
+          render_toast(t(".success"))
+        ].compact
       end
 
       format.html { redirect_back(fallback_location: inbox_path) }
@@ -39,7 +45,10 @@ class AnonymousBlockController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.remove("block_#{params[:id]}")
+        render turbo_stream: [
+          turbo_stream.remove("block_#{params[:id]}"),
+          render_toast(t(".success"))
+        ]
       end
 
       format.html { redirect_back(fallback_location: settings_blocks_path) }

--- a/app/controllers/anonymous_block_controller.rb
+++ b/app/controllers/anonymous_block_controller.rb
@@ -16,12 +16,13 @@ class AnonymousBlockController < ApplicationController
       target_user: question.user
     )
 
-    inbox_id = question.inboxes.first.id
+    inbox_id = question.inboxes.first&.id
     question.inboxes.first&.destroy
 
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: turbo_stream.remove("inbox_#{inbox_id}")
+          inbox_id ? turbo_stream.remove("inbox_#{inbox_id}") : nil,
       end
 
       format.html { redirect_back(fallback_location: inbox_path) }

--- a/app/controllers/concerns/turbo_streamable.rb
+++ b/app/controllers/concerns/turbo_streamable.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module TurboStreamable
+  extend ActiveSupport::Concern
+
+  included do |controller|
+    around_action :handle_error, only: controller.respond_to?(:turbo_stream_actions) ? controller.turbo_stream_actions : []
+  end
+
+  def render_toast(message, success = true)
+    turbo_stream.append("toasts", partial: "shared/toast", locals: { message:, success: })
+  end
+
+  class_methods do
+    def render_toast = render_toast
+  end
+
+  private
+
+  def handle_error
+    yield
+  rescue Errors::Base => e
+    render_error I18n.t(e.locale_tag)
+  rescue KeyError, ActionController::ParameterMissing => e
+    render_error t("errors.parameter_error", parameter: e.is_a?(KeyError) ? e.key : e.param.capitalize)
+  rescue Dry::Types::CoercionError, Dry::Types::ConstraintError
+    render_error t("errors.invalid_parameter")
+  rescue ActiveRecord::RecordNotFound
+    render_error t("errors.record_not_found")
+  end
+
+  def render_error(message)
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: render_toast(message, false)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/turbo_streamable.rb
+++ b/app/controllers/concerns/turbo_streamable.rb
@@ -20,7 +20,7 @@ module TurboStreamable
   rescue Errors::Base => e
     render_error I18n.t(e.locale_tag)
   rescue KeyError, ActionController::ParameterMissing => e
-    render_error t("errors.parameter_error", parameter: e.is_a?(KeyError) ? e.key : e.param.capitalize)
+    render_error t("errors.parameter_error", parameter: e.instance_of?(KeyError) ? e.key : e.param.capitalize)
   rescue Dry::Types::CoercionError, Dry::Types::ConstraintError
     render_error t("errors.invalid_parameter")
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/concerns/turbo_streamable.rb
+++ b/app/controllers/concerns/turbo_streamable.rb
@@ -3,16 +3,14 @@
 module TurboStreamable
   extend ActiveSupport::Concern
 
-  included do |controller|
-    around_action :handle_error, only: controller.respond_to?(:turbo_stream_actions) ? controller.turbo_stream_actions : []
+  class_methods do
+    def turbo_stream_actions(*actions)
+      around_action :handle_error, only: actions
+    end
   end
 
   def render_toast(message, success = true)
     turbo_stream.append("toasts", partial: "shared/toast", locals: { message:, success: })
-  end
-
-  class_methods do
-    def render_toast = render_toast
   end
 
   private

--- a/app/controllers/settings/mutes_controller.rb
+++ b/app/controllers/settings/mutes_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Settings::MutesController < ApplicationController
+  include TurboStreamable
+
   before_action :authenticate_user!
 
-  def turbo_stream_actions = %i[create destroy]
-
-  include TurboStreamable
+  turbo_stream_actions :create, :destroy
 
   def index
     @users = current_user.muted_users

--- a/app/controllers/settings/mutes_controller.rb
+++ b/app/controllers/settings/mutes_controller.rb
@@ -3,6 +3,10 @@
 class Settings::MutesController < ApplicationController
   before_action :authenticate_user!
 
+  def turbo_stream_actions = %i[create destroy]
+
+  include TurboStreamable
+
   def index
     @users = current_user.muted_users
     @rules = MuteRule.where(user: current_user)
@@ -15,7 +19,8 @@ class Settings::MutesController < ApplicationController
       format.turbo_stream do
         render turbo_stream: [
           turbo_stream.replace("form", partial: "settings/mutes/form"),
-          turbo_stream.append("rules", partial: "settings/mutes/rule", locals: { rule: result[:resource] })
+          turbo_stream.append("rules", partial: "settings/mutes/rule", locals: { rule: result[:resource] }),
+          render_toast(t(".success"))
         ]
       end
 
@@ -32,7 +37,10 @@ class Settings::MutesController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.remove("rule_#{params[:id]}")
+        render turbo_stream: [
+          turbo_stream.remove("rule_#{params[:id]}"),
+          render_toast(t(".success"))
+        ]
       end
 
       format.html { redirect_to settings_muted_path }

--- a/app/javascript/retrospring/controllers/toast_controller.ts
+++ b/app/javascript/retrospring/controllers/toast_controller.ts
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+import { showNotification } from "utilities/notifications";
+
+export default class extends Controller<HTMLElement> {
+  static values = {
+    message: String,
+    success: Boolean
+  };
+
+  declare readonly messageValue: string;
+  declare readonly successValue: boolean;
+
+  connect(): void {
+    showNotification(this.messageValue, this.successValue);
+    this.element.remove();
+  }
+}

--- a/app/javascript/retrospring/initializers/stimulus.ts
+++ b/app/javascript/retrospring/initializers/stimulus.ts
@@ -9,6 +9,7 @@ import ThemeController from "retrospring/controllers/theme_controller";
 import CapabilitiesController from "retrospring/controllers/capabilities_controller";
 import CropperController from "retrospring/controllers/cropper_controller";
 import InboxSharingController from "retrospring/controllers/inbox_sharing_controller";
+import ToastController from "retrospring/controllers/toast_controller";
 
 /**
  * This module sets up Stimulus and our controllers
@@ -29,4 +30,5 @@ export default function (): void {
   window['Stimulus'].register('format-popup', FormatPopupController);
   window['Stimulus'].register('inbox-sharing', InboxSharingController);
   window['Stimulus'].register('theme', ThemeController);
+  window['Stimulus'].register('toast', ToastController);
 }

--- a/app/views/layouts/base.html.haml
+++ b/app/views/layouts/base.html.haml
@@ -31,7 +31,7 @@
     = render 'shared/announcements'
     = yield
     = render "shared/formatting"
-    #toasts.d-none
+    .d-none#toasts
     - if Rails.env.development?
       #debug
         %hr

--- a/app/views/layouts/base.html.haml
+++ b/app/views/layouts/base.html.haml
@@ -31,6 +31,7 @@
     = render 'shared/announcements'
     = yield
     = render "shared/formatting"
+    #toasts.d-none
     - if Rails.env.development?
       #debug
         %hr

--- a/app/views/shared/_toast.html.haml
+++ b/app/views/shared/_toast.html.haml
@@ -1,0 +1,1 @@
+.d-none{ data: { controller: "toast", toast_message_value: message, toast_success_value: success } }

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -160,6 +160,11 @@ en:
       create:
         success: "Your account is currently being exported. This will take a little while."
         error: "Exporting is currently not possible."
+    mutes:
+      create:
+        success: "Sucessfully created mute rule"
+      destroy:
+        success: "Successfully removed mute rule"
     privacy:
       update:
         success: :settings.profile.update.success

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -144,6 +144,11 @@ en:
         zero: "You are not currently subscribed to push notifications on any devices."
         one: "You are currently receiving push notifications on one device."
         other: "You are currently receiving push notifications on %{count} devices."
+  anonymous_block:
+    create:
+      success: "Successfully blocked user."
+    destroy:
+      success: "Successfully unblocked user."
   inbox:
     author:
       info: "No questions from @%{author} found, showing entries from all users instead!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,11 +171,5 @@ Rails.application.routes.draw do
 
   get "/nodeinfo/2.1", to: "well_known/node_info#nodeinfo", as: :node_info
 
-  if Rails.env.test?
-    get "turbo_streamable" => "turbo_streamable_test#create"
-    get "turbo_streamable_blocked" => "turbo_streamable_test#blocked"
-    get "turbo_streamable_not_found" => "turbo_streamable_test#not_found"
-  end
-
   puts "processing time of routes.rb: #{"#{(Time.zone.now - start).round(3).to_s.ljust(5, '0')}s".light_green}"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,5 +171,11 @@ Rails.application.routes.draw do
 
   get "/nodeinfo/2.1", to: "well_known/node_info#nodeinfo", as: :node_info
 
+  if Rails.env.test?
+    get "turbo_streamable" => "turbo_streamable_test#create"
+    get "turbo_streamable_blocked" => "turbo_streamable_test#blocked"
+    get "turbo_streamable_not_found" => "turbo_streamable_test#not_found"
+  end
+
   puts "processing time of routes.rb: #{"#{(Time.zone.now - start).round(3).to_s.ljust(5, '0')}s".light_green}"
 end

--- a/spec/controllers/anonymous_block_controller_spec.rb
+++ b/spec/controllers/anonymous_block_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe AnonymousBlockController, type: :controller do
   describe "#create" do
-    subject { post(:create, params:) }
+    subject { post(:create, params:, format: :turbo_stream) }
 
     context "user signed in" do
       let(:user) { FactoryBot.create(:user) }
@@ -22,6 +22,29 @@ describe AnonymousBlockController, type: :controller do
 
         it "creates an anonymous block" do
           expect { subject }.to(change { AnonymousBlock.count }.by(1))
+        end
+
+        it "contains the inbox entry removal turbo stream action" do
+          subject
+
+          expect(response.body).to include "turbo-stream action=\"remove\" target=\"inbox_#{inbox.id}"
+        end
+      end
+
+      context "when all required parameters are given, but no inbox entry exists" do
+        let(:question) { FactoryBot.create(:question, author_identifier: "someidentifier") }
+        let(:params) do
+          { question: question.id }
+        end
+
+        it "creates an anonymous block" do
+          expect { subject }.to(change { AnonymousBlock.count }.by(1))
+        end
+
+        it "doesn't contain the inbox entry removal turbo stream action" do
+          subject
+
+          expect(response.body).not_to include "turbo-stream action=\"remove\" target=\"inbox_"
         end
       end
 

--- a/spec/controllers/concerns/turbo_streamable_spec.rb
+++ b/spec/controllers/concerns/turbo_streamable_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TurboStreamableTestController < ApplicationController
+  include TurboStreamable
+
+  turbo_stream_actions :create, :blocked, :not_found
+
+  def create
+    params.require :message
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: render_toast("success!")
+      end
+    end
+  end
+
+  def blocked
+    raise Errors::Blocked
+  end
+
+  def not_found
+    raise ActiveRecord::RecordNotFound
+  end
+end
+
+describe TurboStreamableTestController, type: :controller do
+  render_views
+
+  before do
+    routes.disable_clear_and_finalize = true
+    routes.draw do
+      get "turbo_streamable" => "turbo_streamable_test#create"
+      get "turbo_streamable_blocked" => "turbo_streamable_test#blocked"
+      get "turbo_streamable_not_found" => "turbo_streamable_test#not_found"
+    end
+    routes.finalize!
+  end
+
+  shared_examples_for "it returns a toast as Turbo Stream response" do |action, message|
+    subject { get action, format: :turbo_stream }
+
+    it "returns a toast as Turbo Stream response" do
+      subject
+
+      expect(response.header["Content-Type"]).to include "text/vnd.turbo-stream.html"
+      expect(response.body).to include message
+    end
+  end
+
+  describe "#create" do
+    context "gets called with the proper parameters" do
+      subject { get :create, format: :turbo_stream, params: { message: "test" } }
+
+      it "returns a toast as Turbo Stream response" do
+        subject
+
+        expect(response.header["Content-Type"]).to include "text/vnd.turbo-stream.html"
+        expect(response.body).to include "success!"
+      end
+    end
+
+    context "gets called with the wrong parameters" do
+      it_behaves_like "it returns a toast as Turbo Stream response", :create, "Message is required"
+    end
+  end
+
+  it_behaves_like "it returns a toast as Turbo Stream response", :create, "Message is required"
+  it_behaves_like "it returns a toast as Turbo Stream response", :blocked, "You have been blocked from performing this request"
+  it_behaves_like "it returns a toast as Turbo Stream response", :not_found, "Record not found"
+end

--- a/spec/controllers/concerns/turbo_streamable_spec.rb
+++ b/spec/controllers/concerns/turbo_streamable_spec.rb
@@ -2,31 +2,39 @@
 
 require "rails_helper"
 
-class TurboStreamableTestController < ApplicationController
-  include TurboStreamable
+describe ApplicationController, type: :controller do
+  controller do
+    include TurboStreamable
 
-  turbo_stream_actions :create, :blocked, :not_found
+    turbo_stream_actions :create, :blocked, :not_found
 
-  def create
-    params.require :message
+    def create
+      params.require :message
 
-    respond_to do |format|
-      format.turbo_stream do
-        render turbo_stream: render_toast("success!")
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: render_toast("success!")
+        end
       end
+    end
+
+    def blocked
+      raise Errors::Blocked
+    end
+
+    def not_found
+      raise ActiveRecord::RecordNotFound
     end
   end
 
-  def blocked
-    raise Errors::Blocked
+  before do
+    routes.draw do
+      get "create" => "anonymous#create"
+      get "blocked" => "anonymous#blocked"
+      get "not_found" => "anonymous#not_found"
+    end
   end
 
-  def not_found
-    raise ActiveRecord::RecordNotFound
-  end
-end
-
-describe TurboStreamableTestController, type: :controller do
   render_views
 
   shared_examples_for "it returns a toast as Turbo Stream response" do |action, message|

--- a/spec/controllers/concerns/turbo_streamable_spec.rb
+++ b/spec/controllers/concerns/turbo_streamable_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe ApplicationController, type: :controller do
+describe TurboStreamable, type: :controller do
   controller do
     include TurboStreamable
 

--- a/spec/controllers/concerns/turbo_streamable_spec.rb
+++ b/spec/controllers/concerns/turbo_streamable_spec.rb
@@ -29,16 +29,6 @@ end
 describe TurboStreamableTestController, type: :controller do
   render_views
 
-  before do
-    routes.disable_clear_and_finalize = true
-    routes.draw do
-      get "turbo_streamable" => "turbo_streamable_test#create"
-      get "turbo_streamable_blocked" => "turbo_streamable_test#blocked"
-      get "turbo_streamable_not_found" => "turbo_streamable_test#not_found"
-    end
-    routes.finalize!
-  end
-
   shared_examples_for "it returns a toast as Turbo Stream response" do |action, message|
     subject { get action, format: :turbo_stream }
 

--- a/spec/controllers/settings/mutes_controller_spec.rb
+++ b/spec/controllers/settings/mutes_controller_spec.rb
@@ -19,7 +19,7 @@ describe Settings::MutesController, type: :controller do
   end
 
   describe "#create" do
-    subject { post :create, params: { muted_phrase: "foo" } }
+    subject { post :create, params: { muted_phrase: "foo" }, format: :turbo_stream }
 
     context "user signed in" do
       let(:user) { FactoryBot.create(:user) }
@@ -29,11 +29,17 @@ describe Settings::MutesController, type: :controller do
       it "creates a mute rule" do
         expect { subject }.to(change { MuteRule.count }.by(1))
       end
+
+      it "contains a turbo stream append tag" do
+        subject
+
+        expect(response.body).to include "turbo-stream action=\"append\" target=\"rules\""
+      end
     end
   end
 
   describe "#destroy" do
-    subject { delete :destroy, params: }
+    subject { delete :destroy, params:, format: :turbo_stream }
 
     context "user signed in" do
       let(:user) { FactoryBot.create(:user) }
@@ -46,6 +52,12 @@ describe Settings::MutesController, type: :controller do
         subject
 
         expect(MuteRule.exists?(rule.id)).to eq(false)
+      end
+
+      it "contains a turbo stream remove tag" do
+        subject
+
+        expect(response.body).to include "turbo-stream action=\"remove\" target=\"rule_#{rule.id}\""
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # anonymous controllers will infer ApplicationController instead of the
+  # described class
+  config.infer_base_class_for_anonymous_controllers = false
+
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :helper
 end


### PR DESCRIPTION
_Toasts in `turbo_stream` responses? For errors even?_

For a long time I kinda struggled with the best ways to implement this and I kinda found a way to achieve this now.

I added a `TurboStreamable` concern which adds toast capability for success/error messages.

Handling of errors is "somewhat" automated. The concern uses the `turbo_stream_actions` method of the parent controller to figure out which actions use Turbo Stream responses, and these actions get wrapped with an error handler that renders a toast for the most common exception types (analogous to `AjaxController`)

It also adds the general `render_toast` method to the invoking controller, adding the ability to send success toast messages. I implemented this into `Settings::MutesController` and `AnonymousBlocksController` (while I was at it, I also fixed #997)

**Testing:**
* Test toasts for anonymous block/mute rule creation and deletion
* Test error toasts
  * _Hint: The easiest way to achieve this one is to create a mute rule and then adjust the action path in the delete button to point to a different ID_