### PR TITLE
Add default database/redis connections to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - redis
     environment:
       - SPROCKETS_CACHE=/cache
+      - DATABASE_URL=postgres://postgres:justask@postgres/justask_development?pool=25
+      - REDIS_URL=redis://redis:6379
     volumes:
       - ./:/app
       - cache:/cache


### PR DESCRIPTION
For Docker-based dev environments the only step required is now copying `config/justask.yml.example` to `config/justask.yml`.