### PR TITLE
More services cleanup

### DIFF
--- a/app/controllers/well_known/node_info_controller.rb
+++ b/app/controllers/well_known/node_info_controller.rb
@@ -8,7 +8,7 @@ class WellKnown::NodeInfoController < ApplicationController
       links: [
         rel:  "http://nodeinfo.diaspora.software/ns/schema/2.1",
         href: node_info_url
-      ]
+      ],
     }
   end
 
@@ -21,12 +21,12 @@ class WellKnown::NodeInfoController < ApplicationController
       protocols:         %i[],
       services:          {
         inbound:  inbound_services,
-        outbound: outbound_services
+        outbound: outbound_services,
       },
       usage:             usage_stats,
       # We don't implement this so we can always return true for now
       openRegistrations: true,
-      metadata:          {}
+      metadata:          {},
     }
   end
 
@@ -36,23 +36,19 @@ class WellKnown::NodeInfoController < ApplicationController
     {
       name:       "Retrospring",
       version:    Retrospring::Version.to_s,
-      repository: "https://github.com/Retrospring/retrospring"
+      repository: "https://github.com/Retrospring/retrospring",
     }
   end
 
   def usage_stats
     {
       users: {
-        total: User.count
-      }
+        total: User.count,
+      },
     }
   end
 
   def inbound_services = []
 
-  def outbound_services
-    {
-      "twitter" => APP_CONFIG.dig("sharing", "twitter", "enabled")
-    }.select { |_service, available| available }.keys
-  end
+  def outbound_services = []
 end

--- a/app/models/notification/service_token_expired.rb
+++ b/app/models/notification/service_token_expired.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class Notification::ServiceTokenExpired < Notification
-end

--- a/app/models/notification/twitter_token_expired.rb
+++ b/app/models/notification/twitter_token_expired.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class Notification::TwitterTokenExpired < Notification::ServiceTokenExpired
-end

--- a/app/models/user/expired_service_connection.rb
+++ b/app/models/user/expired_service_connection.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-# stub model for notifying about expired service connections
-class User::ExpiredServiceConnection < User
-end

--- a/app/models/user/expired_twitter_service_connection.rb
+++ b/app/models/user/expired_twitter_service_connection.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class User::ExpiredTwitterServiceConnection < User::ExpiredServiceConnection
-end

--- a/app/views/notifications/type/_expiredtwitterserviceconnection.html.haml
+++ b/app/views/notifications/type/_expiredtwitterserviceconnection.html.haml
@@ -1,8 +1,0 @@
-.d-flex.notification
-  .flex-shrink-0.notification__icon
-    %i.fa.fa-2x.fa-fw.fa-twitter
-  .flex-grow-1
-    %h6.notification__user
-      = t(".heading")
-    .notification__text
-      = t(".text_html", settings_sharing: link_to(t(".settings_services"), services_path))

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -27,10 +27,11 @@ en:
         header: "Share your answers"
         body_html: |
           <p>Want your followers on another platform to see your %{app_name} answers?
-          You can configure automatic sharing to your favourite platforms easily.</p>
+          You can easily share them to your favourite platforms.</p>
 
-          <p class="text-muted">Not sure if it's a favourite, but at the moment only
-          <b>Twitter</b> is supported.</p>
+          <p class="text-muted">We support <strong>Tumblr</strong>, <strong>Twitter</strong>,
+          and many other services including <strong>Mastodon</strong> and
+          <strong>Misskey</strong>.</p>
       customize:
         header: "Customise your experience"
         body_html: |

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -359,10 +359,6 @@ en:
         heading: "Push notifications are failing to send to one of your devices."
         text_html: "Please check the %{settings_push} if you still want to be notified."
         settings_push: "push notification settings"
-      expiredtwitterserviceconnection:
-        heading: "Twitter connection expired"
-        text_html: "If you would like to continue automatically sharing your answers to Twitter, head to %{settings_sharing} and re-connect your account."
-        settings_services: "Sharing Settings"
   settings:
     account:
       email_confirm: "Currently awaiting confirmation for %{resource}"

--- a/db/migrate/20230212181044_remove_expired_service_connection_notifications.rb
+++ b/db/migrate/20230212181044_remove_expired_service_connection_notifications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveExpiredServiceConnectionNotifications < ActiveRecord::Migration[6.1]
+  def up = Notification.where(type: "Notification::ServiceTokenExpired").delete_all
+
+  def down = raise ActiveRecord::IrreversibleMigration
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_05_162800) do
+ActiveRecord::Schema.define(version: 2023_02_12_181044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/well_known/node_info_controller_spec.rb
+++ b/spec/controllers/well_known/node_info_controller_spec.rb
@@ -13,9 +13,9 @@ describe WellKnown::NodeInfoController do
                              "links" => [
                                {
                                  "rel"  => "http://nodeinfo.diaspora.software/ns/schema/2.1",
-                                 "href" => "http://test.host/nodeinfo/2.1"
+                                 "href" => "http://test.host/nodeinfo/2.1",
                                }
-                             ]
+                             ],
                            })
     end
   end
@@ -44,44 +44,8 @@ describe WellKnown::NodeInfoController do
         expect(parsed["software"]).to eq({
                                            "name"       => "Retrospring",
                                            "version"    => "2023.0102.1",
-                                           "repository" => "https://github.com/Retrospring/retrospring"
+                                           "repository" => "https://github.com/Retrospring/retrospring",
                                          })
-      end
-    end
-
-    context "Twitter integration enabled" do
-      before do
-        stub_const("APP_CONFIG", {
-                     "sharing" => {
-                       "twitter" => {
-                         "enabled" => true
-                       }
-                     }
-                   })
-      end
-
-      it "includes Twitter in outbound services" do
-        subject
-        parsed = JSON.parse(response.body)
-        expect(parsed.dig("services", "outbound")).to include("twitter")
-      end
-    end
-
-    context "Twitter integration disabled" do
-      before do
-        stub_const("APP_CONFIG", {
-                     "sharing" => {
-                       "twitter" => {
-                         "enabled" => false
-                       }
-                     }
-                   })
-      end
-
-      it "includes Twitter in outbound services" do
-        subject
-        parsed = JSON.parse(response.body)
-        expect(parsed.dig("services", "outbound")).to_not include("twitter")
       end
     end
 


### PR DESCRIPTION
- remove twitter from outbound services
- don't need these service expired notifications anymore, they would've broken the notifications page
- reword "share your answers" bit on the landing page