### PR TITLE
remove ruby-progressbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,6 @@ gem "rolify", "~> 6.0"
 gem "dry-initializer", "~> 3.1"
 gem "dry-types", "~> 1.7"
 
-gem "ruby-progressbar"
-
 gem "pghero"
 gem "rails_admin"
 gem "sentry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,6 @@ DEPENDENCIES
   rspec-sidekiq (~> 3.0)
   rubocop (~> 1.47)
   rubocop-rails (~> 2.18)
-  ruby-progressbar
   rubyzip (~> 2.3)
   sanitize
   sassc-rails


### PR DESCRIPTION
not needed anymore after we got rid of some rake tasks in #899 

obsoletes #1127 