### PR TITLE
add rel=me to profile links

### DIFF
--- a/app/views/user/_profile.html.haml
+++ b/app/views/user/_profile.html.haml
@@ -32,7 +32,7 @@
     - unless user.profile.website.blank?
       .profile__website
         %i.fa.fa-fw.fa-globe
-        %a{ href: user.profile.website, target: "_blank", rel: "nofollow" }= user.profile.display_website
+        %a{ href: user.profile.website, target: "_blank", rel: "nofollow me" }= user.profile.display_website
     - unless user.profile.location.blank?
       .profile__location
         %i.fa.fa-fw.fa-location-arrow


### PR DESCRIPTION
this allows mastodon to display profile links to Retrospring as verified in mastodon profiles