### PR TITLE
Ignore carrierwave_backgrounder in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
+    ignore:
+      - dependency-name: 'carrierwave_backgrounder'
     allow:
       - dependency-type: direct
 


### PR DESCRIPTION
It slips into a sentry-related update PR, and it won't update anyway since it's a fork from us.