### PR TITLE
Rewrite WebPush enable handler to properly catch errors

### DIFF
--- a/app/javascript/retrospring/features/webpush/enable.ts
+++ b/app/javascript/retrospring/features/webpush/enable.ts
@@ -3,52 +3,53 @@ import I18n from "retrospring/i18n";
 import { showNotification } from "utilities/notifications";
 import { Buffer } from "buffer";
 
-export function enableHandler (event: Event): void {
+export async function enableHandler (event: Event): Promise<void> {
   event.preventDefault();
   const sender = event.target as HTMLButtonElement;
 
   try {
-    getServiceWorker()
-      .then(subscribe)
-      .then(async subscription => {
-        return Notification.requestPermission().then(permission => {
-          if (permission != "granted") {
-            return;
-          }
+    const registration = await getServiceWorker();
+    const subscription = await subscribe(registration);
+    const permission = await Notification.requestPermission();
 
-          post('/ajax/webpush', {
-            body: {
-              subscription
-            },
-            contentType: 'application/json'
-          }).then(async response => {
-            const data = await response.json;
-
-            if (data.success) {
-              new Notification(I18n.translate("frontend.push_notifications.subscribe.success.title"), {
-                body: I18n.translate("frontend.push_notifications.subscribe.success.body")
-              });
-
-              document.querySelectorAll<HTMLButtonElement>('button[data-action="push-disable"], button[data-action="push-remove-all"]')
-                .forEach(button => button.classList.remove('d-none'));
-
-              sender.classList.add('d-none');
-              document.querySelector<HTMLDivElement>('.push-settings')?.classList.add('d-none');
-              localStorage.setItem('dismiss-push-settings-prompt', 'true');
-
-              document.getElementById('subscription-count').textContent = data.message;
-            } else {
-              new Notification(I18n.translate("frontend.push_notifications.fail.title"), {
-                body: I18n.translate("frontend.push_notifications.fail.body")
-              });
-            }
-          });
-        });
-      });
-    } catch (error) {
-      console.error("Failed to set up push notifications", error);
-      showNotification(I18n.translate("frontend.push_notifications.setup_fail"));
+    if (permission != "granted") {
+      return;
     }
+
+    const response = await post('/ajax/webpush', {
+      body: {
+        subscription
+      },
+      contentType: 'application/json'
+    });
+
+    const data = await response.json;
+
+    if (data.success) {
+      new Notification(I18n.translate("frontend.push_notifications.subscribe.success.title"), {
+        body: I18n.translate("frontend.push_notifications.subscribe.success.body")
+      });
+
+      document.querySelectorAll<HTMLButtonElement>('button[data-action="push-disable"], button[data-action="push-remove-all"]')
+        .forEach(button => button.classList.remove('d-none'));
+
+      sender.classList.add('d-none');
+      document.querySelector<HTMLDivElement>('.push-settings')?.classList.add('d-none');
+      localStorage.setItem('dismiss-push-settings-prompt', 'true');
+
+      const subscriptionCountElement = document.getElementById('subscription-count');
+      if (subscriptionCountElement != null) {
+        subscriptionCountElement.textContent = data.message;
+      }
+    } else {
+      new Notification(I18n.translate("frontend.push_notifications.fail.title"), {
+        body: I18n.translate("frontend.push_notifications.fail.body")
+      });
+    }
+  } catch (error) {
+    console.error("Failed to set up push notifications", error);
+    showNotification(I18n.translate("frontend.push_notifications.setup_fail"), false);
+  }
 }
 
 async function getServiceWorker(): Promise<ServiceWorkerRegistration> {


### PR DESCRIPTION
Fixes #1369

**Replication:** (before checking out the PR)
* In (your adblocker of choice) add the "EasyList - Notifications" filter list
* Go into your inbox or the Push Notifications settings and try to enable the notifications
* Nothing happens (no visible error, button states don't change)
* Error in the console about the web request to `/ajax/webpush/key` failing

Above should directly show an error message now when clicking the button to subscribe.

Additionally:
* Fixed the notification style to be an error instead of a success toast.
* Added a null check for the subscription counter (which now threw an error)