### PR TITLE
Properly validate mute rule creation

### DIFF
--- a/app/controllers/concerns/turbo_streamable.rb
+++ b/app/controllers/concerns/turbo_streamable.rb
@@ -23,6 +23,8 @@ module TurboStreamable
     render_error t("errors.parameter_error", parameter: e.instance_of?(KeyError) ? e.key : e.param.capitalize)
   rescue Dry::Types::CoercionError, Dry::Types::ConstraintError
     render_error t("errors.invalid_parameter")
+  rescue ActiveRecord::RecordInvalid => e
+    render_error e.record.errors.full_messages.flatten.join(" ")
   rescue ActiveRecord::RecordNotFound
     render_error t("errors.record_not_found")
   end

--- a/app/models/mute_rule.rb
+++ b/app/models/mute_rule.rb
@@ -3,7 +3,7 @@
 class MuteRule < ApplicationRecord
   belongs_to :user
 
-  validates :muted_phrase, presence: true
+  validates :muted_phrase, length: { minimum: 1 }
 
   def applies_to?(post)
     !!(post.content =~ /\b#{Regexp.escape(muted_phrase)}\b/i)

--- a/app/views/settings/mutes/_form.html.haml
+++ b/app/views/settings/mutes/_form.html.haml
@@ -1,6 +1,6 @@
 #form.form-group
   %form{ action: settings_muted_path, method: "post" }
     .input-group
-      %input.form-control#muted_phrase{ name: :muted_phrase, placeholder: t(".placeholder"), data: { controller: :autofocus } }
+      %input.form-control#muted_phrase{ name: :muted_phrase, placeholder: t(".placeholder"), required: true, minlength: 1, data: { controller: :autofocus } }
       .input-group-append
         %button.btn.btn-primary{ type: "submit" }= t("voc.add")

--- a/app/views/settings/mutes/_form.html.haml
+++ b/app/views/settings/mutes/_form.html.haml
@@ -1,6 +1,6 @@
 #form.form-group
   %form{ action: settings_muted_path, method: "post" }
     .input-group
-      %input.form-control#muted_phrase{ name: :muted_phrase, placeholder: t(".placeholder"), required: true, minlength: 1, data: { controller: :autofocus } }
+      %input.form-control#muted-phrase{ name: :muted_phrase, placeholder: t(".placeholder"), required: true, minlength: 1, data: { controller: :autofocus } }
       .input-group-append
         %button.btn.btn-primary{ type: "submit" }= t("voc.add")

--- a/lib/use_case/mute_rule/create.rb
+++ b/lib/use_case/mute_rule/create.rb
@@ -7,7 +7,7 @@ module UseCase
       option :phrase, type: Types::Coercible::String
 
       def call
-        rule = ::MuteRule.create(
+        rule = ::MuteRule.create!(
           user:,
           muted_phrase: phrase
         )

--- a/spec/controllers/concerns/turbo_streamable_spec.rb
+++ b/spec/controllers/concerns/turbo_streamable_spec.rb
@@ -27,7 +27,7 @@ describe TurboStreamable, type: :controller do
     end
 
     def invalid_record
-      ::MuteRule.create!(muted_phrase: "", user: FactoryBot.create(:user))
+      MuteRule.create!(muted_phrase: "", user: FactoryBot.create(:user))
     end
   end
 

--- a/spec/controllers/concerns/turbo_streamable_spec.rb
+++ b/spec/controllers/concerns/turbo_streamable_spec.rb
@@ -6,7 +6,7 @@ describe TurboStreamable, type: :controller do
   controller do
     include TurboStreamable
 
-    turbo_stream_actions :create, :blocked, :not_found
+    turbo_stream_actions :create, :blocked, :not_found, :invalid_record
 
     def create
       params.require :message
@@ -25,6 +25,10 @@ describe TurboStreamable, type: :controller do
     def not_found
       raise ActiveRecord::RecordNotFound
     end
+
+    def invalid_record
+      ::MuteRule.create!(muted_phrase: "", user: FactoryBot.create(:user))
+    end
   end
 
   before do
@@ -32,6 +36,7 @@ describe TurboStreamable, type: :controller do
       get "create" => "anonymous#create"
       get "blocked" => "anonymous#blocked"
       get "not_found" => "anonymous#not_found"
+      get "invalid_record" => "anonymous#invalid_record"
     end
   end
 
@@ -68,4 +73,5 @@ describe TurboStreamable, type: :controller do
   it_behaves_like "it returns a toast as Turbo Stream response", :create, "Message is required"
   it_behaves_like "it returns a toast as Turbo Stream response", :blocked, "You have been blocked from performing this request"
   it_behaves_like "it returns a toast as Turbo Stream response", :not_found, "Record not found"
+  it_behaves_like "it returns a toast as Turbo Stream response", :invalid_record, "too short"
 end

--- a/spec/lib/use_case/mute_rule/create_spec.rb
+++ b/spec/lib/use_case/mute_rule/create_spec.rb
@@ -11,8 +11,8 @@ describe UseCase::MuteRule::Create do
     context "phrase is empty" do
       let(:phrase) { "" }
 
-      it "does not create the rule" do
-        expect { subject }.not_to(change { MuteRule.count })
+      it "raises an error" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 


### PR DESCRIPTION
Fixes #1066

Creating empty mute rules now doesn't work, because the frontend validates (using `required minlength=1` attributes). The backend now validates using `length` instead of `presence` (even though presence uses `allow_blank: false` by default so I have no idea why this has been failing).

Added support in `TurboStreamable` to handle validation errors too.