### PR TITLE
Disable `Metrics/*Length` and `AbcSize` cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,3 +123,7 @@ Style/TrailingCommaInHashLiteral:
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma
+
+Style/RedundantSelf:
+  Exclude:
+    - app/models/**/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,39 +31,25 @@ Lint/NestedMethodDefinition:
 ### Metrics
 
 Metrics/AbcSize:
-  Max: 20
-  Exclude:
-    - 'db/**/*'
+  Enabled: false
 
 Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
-  Max: 15
-  Exclude:
-    - 'db/migrate/*.rb'
+  Enabled: false
 
 Metrics/BlockLength:
-  Exclude:
-    - '*.gemspec'
-    - '**/*.rake'
-    - 'api/**/*'
-    - 'app/api/routes.rb'
-    - 'config/initialize/**/*'
-    - 'config/initializers/**/*'
-    - 'spec/**/*'
+  Enabled: false
 
 Metrics/ClassLength:
-  Exclude:
-    - spec/**/*
+  Enabled: false
 
 Metrics/CyclomaticComplexity:
   Severity: refactor
 
 Metrics/ModuleLength:
-  Exclude:
-    - 'app/api/routes.rb'
-    - 'spec/requests/**/*'
+  Enabled: false
 
 
 ### Style / Layout

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-namespace :justask do # rubocop:disable Metrics/BlockLength
+namespace :justask do
   desc "Gives admin status to a user."
   task :admin, [:screen_name] => :environment do |_t, args|
     abort "screen name required" if args[:screen_name].nil?

--- a/app/controllers/ajax/web_push_controller.rb
+++ b/app/controllers/ajax/web_push_controller.rb
@@ -41,7 +41,7 @@ class Ajax::WebPushController < AjaxController
     @response[:message] = t(".subscription_count", count: current_user.web_push_subscriptions.count)
   end
 
-  def unsubscribe # rubocop:disable Metrics/AbcSize
+  def unsubscribe
     removed = if params.key?(:endpoint)
                 current_user.web_push_subscriptions.where("subscription ->> 'endpoint' = ?", params[:endpoint]).destroy_all
               else

--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -3,7 +3,7 @@
 class InboxController < ApplicationController
   before_action :authenticate_user!
 
-  def show # rubocop:disable Metrics/MethodLength
+  def show
     find_author
     find_inbox_entries
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,10 +117,8 @@ class User < ApplicationRecord
   # @param question [Question] the question to answer
   # @param content [String] the answer content
   def answer(question, content)
-    # rubocop:disable Style/RedundantSelf
     raise Errors::AnsweringOtherBlockedSelf if question.user&.blocking?(self)
     raise Errors::AnsweringSelfBlockedOther if self.blocking?(question.user)
-    # rubocop:enable Style/RedundantSelf
 
     Retrospring::Metrics::QUESTIONS_ANSWERED.increment
 
@@ -132,10 +130,8 @@ class User < ApplicationRecord
   def answered?(question) = question.answers.pluck(:user_id).include? id
 
   def comment(answer, content)
-    # rubocop:disable Style/RedundantSelf
     raise Errors::CommentingSelfBlockedOther if self.blocking?(answer.user)
     raise Errors::CommentingOtherBlockedSelf if answer.user.blocking?(self)
-    # rubocop:enable Style/RedundantSelf
 
     Retrospring::Metrics::COMMENTS_CREATED.increment
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
+class User < ApplicationRecord
   include User::Relationship
   include User::Relationship::Follow
   include User::Relationship::Block

--- a/app/models/user/reaction_methods.rb
+++ b/app/models/user/reaction_methods.rb
@@ -4,10 +4,8 @@ module User::ReactionMethods
   # smiles an answer or comment
   # @param item [ApplicationRecord] the answer/comment to smile
   def smile(item)
-    # rubocop:disable Style/RedundantSelf
     raise Errors::ReactingSelfBlockedOther if self.blocking?(item.user)
     raise Errors::ReactingOtherBlockedSelf if item.user.blocking?(self)
-    # rubocop:enable Style/RedundantSelf
 
     ::Appendable::Reaction.create!(user: self, parent: item, content: "🙂")
   end

--- a/app/models/user/relationship/follow.rb
+++ b/app/models/user/relationship/follow.rb
@@ -19,10 +19,8 @@ class User
       # Follow an user
       def follow(target_user)
         raise Errors::FollowingSelf if target_user == self
-        # rubocop:disable Style/RedundantSelf
         raise Errors::FollowingOtherBlockedSelf if target_user.blocking?(self)
         raise Errors::FollowingSelfBlockedOther if self.blocking?(target_user)
-        # rubocop:enable Style/RedundantSelf
 
         create_relationship(active_follow_relationships, target_user)
       end


### PR DESCRIPTION
These are massive blockers in the development workflow and don't really help much in terms of clean code. Our methods/classes/modules are already relatively short, and complexity-by-number is not as important as actual readability.