### PR TITLE
Fix `build-image` workflow

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ ARG BUNDLER_VERSION=2.3.18
 ENV RAILS_ENV=production
 
 # update and install dependencies
-RUN zypper --gpg-auto-import-keys -n addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
+RUN zypper -n --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
  && zypper up -y \
  && zypper in -y \
       # build dependencies (ruby-install)

--- a/Containerfile
+++ b/Containerfile
@@ -15,8 +15,8 @@ ARG BUNDLER_VERSION=2.3.18
 ENV RAILS_ENV=production
 
 # update and install dependencies
-RUN zypper -n --gpg-auto-import-keys addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
- && zypper up -y \
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
+ && zypper --gpg-auto-import-keys up -y \
  && zypper in -y \
       # build dependencies (ruby-install)
       automake         \

--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ ARG BUNDLER_VERSION=2.3.18
 ENV RAILS_ENV=production
 
 # update and install dependencies
-RUN zypper -n addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo --gpg-auto-import-keys \
+RUN zypper --gpg-auto-import-keys -n addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
  && zypper up -y \
  && zypper in -y \
       # build dependencies (ruby-install)

--- a/Containerfile
+++ b/Containerfile
@@ -35,8 +35,8 @@ RUN zypper up -y \
       gcc-c++          \
       git              \
       libidn-devel     \
-      nodejs14         \
-      npm14            \
+      nodejs16         \
+      npm16            \
       postgresql-devel \
       # runtime dependencies
       ImageMagick      \

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 # Container image for a production Retrospring setup
 
-FROM registry.opensuse.org/opensuse/leap:15.4
+FROM registry.opensuse.org/opensuse/leap:15.5
 
 LABEL org.opencontainers.image.title="Retrospring (production)"
 LABEL org.opencontainers.image.description="Image containing everything to run Retrospring in production mode.  Do not use this for development."

--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,6 @@ ENV RAILS_ENV=production
 
 # update and install dependencies
 RUN zypper addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
- && zypper refresh \
  && zypper up -y \
  && zypper in -y \
       # build dependencies (ruby-install)

--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ ARG BUNDLER_VERSION=2.3.18
 ENV RAILS_ENV=production
 
 # update and install dependencies
-RUN zypper addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
+RUN zypper -n addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
  && zypper up -y \
  && zypper in -y \
       # build dependencies (ruby-install)

--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,9 @@ ARG BUNDLER_VERSION=2.3.18
 ENV RAILS_ENV=production
 
 # update and install dependencies
-RUN zypper up -y \
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
+ && zypper refresh \
+ && zypper up -y \
  && zypper in -y \
       # build dependencies (ruby-install)
       automake         \

--- a/Containerfile
+++ b/Containerfile
@@ -32,6 +32,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:languages:no
       tar              \
       xz               \
       zlib-devel       \
+      curl             \
       # build dependencies (app)
       gcc-c++          \
       git              \

--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ ARG BUNDLER_VERSION=2.3.18
 ENV RAILS_ENV=production
 
 # update and install dependencies
-RUN zypper -n addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo \
+RUN zypper -n addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/15.5/devel:languages:nodejs.repo --gpg-auto-import-keys \
  && zypper up -y \
  && zypper in -y \
       # build dependencies (ruby-install)


### PR DESCRIPTION
Some package sources can't be resolved. Let's see if updating the Leap version fixes it.