### PR TITLE
Properly show validation errors in settings controllers

### DIFF
--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -19,6 +19,6 @@ class Settings::PrivacyController < ApplicationController
     else
       flash[:error] = t(".error")
     end
-    redirect_to settings_privacy_path
+    render :edit
   end
 end

--- a/app/controllers/settings/profile_controller.rb
+++ b/app/controllers/settings/profile_controller.rb
@@ -14,6 +14,6 @@ class Settings::ProfileController < ApplicationController
       flash[:error] = t(".error")
     end
 
-    redirect_to settings_profile_path
+    render :edit
   end
 end

--- a/app/controllers/settings/theme_controller.rb
+++ b/app/controllers/settings/theme_controller.rb
@@ -22,7 +22,7 @@ class Settings::ThemeController < ApplicationController
     else
       flash[:error] = t(".error", errors: current_user.theme.errors.messages.flatten.join(" "))
     end
-    redirect_to settings_theme_path
+    render :edit
   end
 
   def destroy

--- a/spec/controllers/settings/privacy_controller_spec.rb
+++ b/spec/controllers/settings/privacy_controller_spec.rb
@@ -13,7 +13,7 @@ describe Settings::PrivacyController, type: :controller do
 
       it "renders the edit template" do
         subject
-        expect(response).to render_template("edit")
+        expect(response).to render_template(:edit)
       end
     end
   end
@@ -43,7 +43,7 @@ describe Settings::PrivacyController, type: :controller do
 
       it "redirects to the privacy settings page" do
         subject
-        expect(response).to redirect_to(:settings_privacy)
+        expect(response).to render_template(:edit)
       end
     end
   end

--- a/spec/controllers/settings/profile_controller_spec.rb
+++ b/spec/controllers/settings/profile_controller_spec.rb
@@ -37,7 +37,7 @@ describe Settings::ProfileController, type: :controller do
 
       it "redirects to the edit_user_profile page" do
         subject
-        expect(response).to redirect_to(:settings_profile)
+        expect(response).to render_template(:edit)
       end
     end
   end

--- a/spec/controllers/settings/theme_controller_spec.rb
+++ b/spec/controllers/settings/theme_controller_spec.rb
@@ -61,7 +61,7 @@ describe Settings::ThemeController, type: :controller do
 
         it "renders the edit template" do
           subject
-          expect(response).to redirect_to(:settings_theme)
+          expect(response).to render_template(:edit)
         end
       end
 
@@ -75,7 +75,7 @@ describe Settings::ThemeController, type: :controller do
 
         it "renders the edit template" do
           subject
-          expect(response).to redirect_to(:settings_theme)
+          expect(response).to render_template(:edit)
         end
       end
     end


### PR DESCRIPTION
Fixes #1401

Using `redirect_to` doesn't (automatically) pass resources back to the view, so validations in forms are not displayed, causing confusion on what fields actually have errors in them.