### PR TITLE
Add automated GitHub release categorization

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,8 @@ using. We find screenshots (for front-end issues) very helpful.
 We love pull requests! We are very happy to work with you to get your changes
 merged in, however please keep the following in mind.
 
-* Please use the core team standard of `feature/*` or `fix/*` branch naming.
+* Please use the core team standard of `feature/*` or `bugfix/*` branch naming.
+  * Using these branch prefixes tags the Pull Requests with the appropriate labels for release categorization.
 * Adhere to the coding conventions you see in the surrounding code.
 * If you include a new feature also include tests, and make sure they'll pass.
 * Before submitting a pull-request, clean up the history by going over your

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+feature:
+- head-branch: ['^feature', 'feature']
+
+bugfix:
+- head-branch: ['^bugfix', 'bugfix']

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: Added
+      labels:
+        - feature
+    - title: Fixed
+      labels:
+        - bugfix
+    - title: Changed
+      labels:
+        - '*'
+    - title: Developer experience
+      labels:
+        - developer experience
+    - title: Dependency updates
+      labels:
+        - dependencies

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5.0.0-beta.1


### PR DESCRIPTION
To aid us a bit with release creation, I decided to add the Pull Request Labeler action and combining it with GitHub's release configuration, automatically tagging and then categorizing PRs in the changelog.