### PR TITLE
Add use cases for creating and destroying reactions

### DIFF
--- a/lib/use_case/reaction/create.rb
+++ b/lib/use_case/reaction/create.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module UseCase
+  module Reaction
+    class Create < UseCase::Base
+      option :source_user, type: Types.Instance(::User)
+      option :target, type: Types.Instance(::Answer) | Types.Instance(::Comment)
+      option :content, type: Types::Coercible::String, optional: true
+
+      def call
+        reaction = source_user.smile target
+
+        {
+          status:   201,
+          resource: reaction,
+        }
+      end
+    end
+  end
+end

--- a/lib/use_case/reaction/destroy.rb
+++ b/lib/use_case/reaction/destroy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module UseCase
+  module Reaction
+    class Destroy < UseCase::Base
+      option :source_user, type: Types.Instance(::User)
+      option :target, type: Types.Instance(::Answer) | Types.Instance(::Comment)
+
+      def call
+        source_user.unsmile target
+
+        {
+          status:   204,
+          resource: nil,
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/use_case/reaction/create_spec.rb
+++ b/spec/lib/use_case/reaction/create_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UseCase::Reaction::Create do
+  shared_examples_for "valid target type" do
+    it "creates a reaction" do
+      expect { subject }.to change { target.smile_count }.by(1)
+    end
+  end
+
+  subject { UseCase::Reaction::Create.call(source_user: user, target:) }
+
+  let(:user) { FactoryBot.create(:user) }
+
+  context "target is an Answer" do
+    let(:target) { FactoryBot.create(:answer, user:) }
+
+    include_examples "valid target type"
+  end
+
+  context "target is a Comment" do
+    let(:target) { FactoryBot.create(:comment, user:, answer: FactoryBot.create(:answer, user:)) }
+
+    include_examples "valid target type"
+  end
+
+  context "target is a Question" do
+    let(:target) { FactoryBot.create(:question) }
+
+    include_examples "raises an error", Dry::Types::ConstraintError
+  end
+end

--- a/spec/lib/use_case/reaction/create_spec.rb
+++ b/spec/lib/use_case/reaction/create_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe UseCase::Reaction::Create do
   shared_examples_for "valid target type" do
     it "creates a reaction" do
-      expect { subject }.to change { target.smile_count }.by(1)
+      expect { subject }.to change { target.reload.smile_count }.by(1)
     end
   end
 

--- a/spec/lib/use_case/reaction/destroy_spec.rb
+++ b/spec/lib/use_case/reaction/destroy_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UseCase::Reaction::Destroy do
+  shared_examples_for "valid target type" do
+    before do
+      user.smile target
+    end
+
+    it "destroys a reaction" do
+      expect { subject }.to change { target.smile_count }.by(-1)
+    end
+  end
+
+  subject { UseCase::Reaction::Destroy.call(source_user: user, target:) }
+
+  let(:user) { FactoryBot.create(:user) }
+
+  context "target is an Answer" do
+    let(:target) { FactoryBot.create(:answer, user:) }
+
+    include_examples "valid target type"
+  end
+
+  context "target is a Comment" do
+    let(:target) { FactoryBot.create(:comment, user:, answer: FactoryBot.create(:answer, user:)) }
+
+    include_examples "valid target type"
+  end
+end

--- a/spec/lib/use_case/reaction/destroy_spec.rb
+++ b/spec/lib/use_case/reaction/destroy_spec.rb
@@ -9,7 +9,7 @@ describe UseCase::Reaction::Destroy do
     end
 
     it "destroys a reaction" do
-      expect { subject }.to change { target.smile_count }.by(-1)
+      expect { subject }.to change { target.reload.smile_count }.by(-1)
     end
   end
 


### PR DESCRIPTION
More use cases!

Draft because tests fail for some reason and I also need some feedback.

Should we get rid of the `ReactionMethods#(un)smile` in favor for the use cases, instead of just using those methods in the use case?