### PR TITLE
Improve button styling

### DIFF
--- a/app/assets/stylesheets/_utilities.scss
+++ b/app/assets/stylesheets/_utilities.scss
@@ -30,3 +30,7 @@
 .z-n1 {
   z-index: -1;
 }
+
+.grid-row-1 {
+  grid-row: 1;
+}

--- a/app/assets/stylesheets/overrides/_buttons.scss
+++ b/app/assets/stylesheets/overrides/_buttons.scss
@@ -1,5 +1,8 @@
 .btn {
+  --btn-padding-x: 1rem;
+  --btn-border-radius: 2rem;
   color: RGB(var(--body-text));
+  font-weight: bold;
 }
 
 .btn-link:hover {

--- a/app/views/inbox/_entry.html.haml
+++ b/app/views/inbox/_entry.html.haml
@@ -4,13 +4,15 @@
   - if current_user == i.user
     .card-body
       %textarea.form-control.mb-3{ name: "ib-answer", placeholder: t(".placeholder"), data: { id: i.id } }
-      .d-sm-flex
-        %button.btn.btn-success.me-sm-1{ name: "ib-answer", data: { ib_id: i.id } }
-          = t("voc.answer")
-        %button.btn.btn-danger.me-sm-1{ name: "ib-destroy", data: { ib_id: i.id } }
-          = t("voc.delete")
-        %p.format-help.ms-auto.align-self-center.mt-2.mt-sm-0.text-center
+      .d-flex.flex-column-reverse.flex-sm-row
+        %p.format-help.me-sm-auto.align-self-center.mb-0.mt-2.mt-sm-0.text-center
           = render "shared/format_link"
+        .d-grid.gap-2.d-sm-block
+          %button.btn.btn-default.text-muted.me-sm-1.mb-sm-0{ name: "ib-destroy", data: { ib_id: i.id } }
+            %i.fa.fa-trash.fa-fw
+            = t("voc.delete")
+          %button.btn.btn-primary.grid-row-1{ name: "ib-answer", data: { ib_id: i.id } }
+            = t("voc.answer")
     - if current_user.sharing_enabled
       .inbox-entry__sharing.text-center.p-2.justify-content-center.d-none{
         data: { controller: "inbox-sharing", inbox_sharing_config_value: "{}", inbox_sharing_auto_close_value: current_user.sharing_autoclose.to_s } }


### PR DESCRIPTION
Buttons are now slightly wider, include an increased border radius, and the font weight is bold. Additionally, the inbox entry layout for buttons is improved as well, as the order/placement was off (since actions are usually on the right).

|         | Before | After |
|---------|--------|-------|
| Mobile  | ![image](https://github.com/Retrospring/retrospring/assets/1774242/de9715a5-5cc4-4b52-b720-78b10c9dc723) | ![image](https://github.com/Retrospring/retrospring/assets/1774242/2ca97c49-4c80-49f5-8c22-ca7abf952b29) |
| Desktop | ![image](https://github.com/Retrospring/retrospring/assets/1774242/ddef96ea-bc5b-419c-86cc-54b1904e200e) | ![image](https://github.com/Retrospring/retrospring/assets/1774242/b02ff0ed-dbab-4400-a451-7e38a3ebbaf7) | 