### PR TITLE
Fix Missing Translation Issue

### DIFF
--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -676,7 +676,7 @@ en:
     questions:
       header:
         title_html: "Viewing all questions from <br><abbr title=%{author_identifier}>%{short}</abbr>"
-      index:
+      show:
         title: "Questions from %{author_identifier}"
   user:
     show_follow:


### PR DESCRIPTION
Resolves #1423 
**Issue**
- We are using the wrong translation path for the page title

**Fix**
- This PR updates the correct translation path

**Screenshot**
![image](https://github.com/Retrospring/retrospring/assets/59338032/5279edf6-1b7e-4714-ae47-af3c01d16027)
