### PR TITLE
Fix disabled button issue for the Inbox Question

### DIFF
--- a/app/javascript/retrospring/features/inbox/entry/delete.ts
+++ b/app/javascript/retrospring/features/inbox/entry/delete.ts
@@ -7,7 +7,6 @@ import { showNotification, showErrorNotification } from 'utilities/notifications
 
 export function deleteEntryHandler(event: Event): void {
   const element: HTMLButtonElement = event.target as HTMLButtonElement;
-  element.disabled = true;
 
   const data = {
     id: element.getAttribute('data-ib-id')
@@ -22,11 +21,8 @@ export function deleteEntryHandler(event: Event): void {
     confirmButtonText: I18n.translate('voc.delete'),
     cancelButtonText: I18n.translate('voc.cancel'),
     closeOnConfirm: true
-  }, (returnValue) => {
-    if (returnValue === false) {
-      element.disabled = false;
-      return;
-    }
+  }, () => {
+    element.disabled = true;
 
     post('/ajax/delete_inbox', {
       body: data,
@@ -44,6 +40,7 @@ export function deleteEntryHandler(event: Event): void {
         (inboxEntry as HTMLElement).remove();
       })
       .catch(err => {
+        element.disabled = false;
         console.log(err);
         showErrorNotification(I18n.translate('frontend.error.message'));
       });


### PR DESCRIPTION
Resolves: #1427

**Issue**

- In the `deleteEntryHandler`, we are disabling the delete button before the confirmation modal pops up
- On cancel operation, the callback function is not invoked. Hence the button doesn't get re-enabled.
- I believe the package we are using does not invoke the callback function upon cancelation.
- This might have been updated in its recent release if it was the expected behavior before as this code is pretty old.

**The Fix**

- This PR disables the button just before we are making the API call by confirming the deletion.
- Re-enable the button if the API call is unsuccessful