### PR TITLE
Fix Error upon Comment

### DIFF
--- a/app/javascript/retrospring/features/answerbox/comment/new.ts
+++ b/app/javascript/retrospring/features/answerbox/comment/new.ts
@@ -31,10 +31,6 @@ function createComment(input: HTMLInputElement, id: string, counter: Element, gr
         }
         input.value = '';
         counter.innerHTML = String(512);
-
-        const sub = document.querySelector<HTMLElement>(`[data-action=ab-submarine][data-a-id="${id}"]`);
-        sub.dataset.torpedo = "no"
-        sub.children[0].nextSibling.textContent = ' ' + I18n.translate('voc.unsubscribe');
       }
 
       showNotification(data.message, data.success);


### PR DESCRIPTION
**Resolves: #1443** 

### Issue
- The `TypeError` is caused by these changes:
  - https://github.com/Retrospring/retrospring/pull/1417/files#diff-dae21ea85421965fd9b72a386fe3461aaca6bc45c3b67d9dd7930c5b01a584dcL3-L10
  - https://github.com/Retrospring/retrospring/pull/1417/files#diff-c52ed63dab8f18456411306029b0efb69cdba2ea74d61c060ef619c02731330cR1-R3
- And in the following lines we are not getting the `sub`, hence the error:
- https://github.com/Retrospring/retrospring/blob/43140105355219ebf23802d9ac506fdb60a562c9/app/javascript/retrospring/features/answerbox/comment/new.ts#L35-L37

### The Fix
- I believe these lines are no longer needed and this PR aims to remove them.
- Please suggest if you think otherwise. Thanks.