### PR TITLE
Add spacing to sharing buttons

### DIFF
--- a/app/views/inbox/_entry.html.haml
+++ b/app/views/inbox/_entry.html.haml
@@ -30,7 +30,7 @@
             %a.btn.btn-primary.mb-1{ href: "#", data: { inbox_sharing_target: "telegram" }, target: "_blank" }
               %i.fab.fa-telegram.fa-fw
               Telegram
-            %a.btn.btn-primary{ data: { controller: :clipboard, action: "clipboard#copy", inbox_sharing_target: "clipboard" } }
+            %button.btn.btn-primary.mb-1{ data: { controller: :clipboard, action: "clipboard#copy", inbox_sharing_target: "clipboard" } }
               %i.fa.fa-fw.fa-solid.fa-copy
               = t("actions.share.copy")
             %button.btn.btn-primary.mb-1{ data: { controller: "share", action: "share#share", inbox_sharing_target: "other" } }

--- a/app/views/inbox/_entry.html.haml
+++ b/app/views/inbox/_entry.html.haml
@@ -21,22 +21,22 @@
         .align-self-center
           %p.fs-3.fw-bold= t(".sharing.heading")
           %p
-            %a.btn.btn-primary{ href: "https://twitter.com/intent/tweet?text=", data: { inbox_sharing_target: "twitter" }, target: "_blank" }
+            %a.btn.btn-primary.mb-1{ href: "https://twitter.com/intent/tweet?text=", data: { inbox_sharing_target: "twitter" }, target: "_blank" }
               %i.fab.fa-twitter.fa-fw
               Twitter
-            %a.btn.btn-primary{ href: "#", data: { inbox_sharing_target: "tumblr" }, target: "_blank" }
+            %a.btn.btn-primary.mb-1{ href: "#", data: { inbox_sharing_target: "tumblr" }, target: "_blank" }
               %i.fab.fa-tumblr.fa-fw
               Tumblr
-            %a.btn.btn-primary{ href: "#", data: { inbox_sharing_target: "telegram" }, target: "_blank" }
+            %a.btn.btn-primary.mb-1{ href: "#", data: { inbox_sharing_target: "telegram" }, target: "_blank" }
               %i.fab.fa-telegram.fa-fw
               Telegram
             %a.btn.btn-primary{ data: { controller: :clipboard, action: "clipboard#copy", inbox_sharing_target: "clipboard" } }
               %i.fa.fa-fw.fa-solid.fa-copy
               = t("actions.share.copy")
-            %button.btn.btn-primary{ data: { controller: "share", action: "share#share", inbox_sharing_target: "other" } }
+            %button.btn.btn-primary.mb-1{ data: { controller: "share", action: "share#share", inbox_sharing_target: "other" } }
               %i.fa.fa-fw.fa-share-alt
               = t("actions.share.other")
             - if current_user.sharing_custom_url.present?
-              %a.btn.btn-primary{ href: current_user.sharing_custom_url, data: { inbox_sharing_target: "custom" }, target: "_blank" }
+              %a.btn.btn-primary.mb-1{ href: current_user.sharing_custom_url, data: { inbox_sharing_target: "custom" }, target: "_blank" }
                 = current_user.display_sharing_custom_url
           %p.text-muted= t(".sharing.hint_html", settings: link_to(t(".sharing.settings"), settings_sharing_path))

--- a/spec/views/inbox/_entry.html.haml_spec.rb
+++ b/spec/views/inbox/_entry.html.haml_spec.rb
@@ -96,7 +96,7 @@ describe "inbox/_entry.html.haml", type: :view do
 
   it "has a link-button to copy to clipboard" do
     expected_attribute_selectors = %([data-controller="clipboard"][data-action="clipboard#copy"][data-inbox-sharing-target="clipboard"])
-    expect(rendered).to have_css(%(.inbox-entry__sharing a.btn#{expected_attribute_selectors}))
+    expect(rendered).to have_css(%(.inbox-entry__sharing button.btn#{expected_attribute_selectors}))
   end
 
   it "does not have a link-button to share to a custom site" do


### PR DESCRIPTION
Now that there can be linebreaks because of the amount of buttons in the sharing dialog, they are squished together without bottom spacing. This PR fixes that.