### PR TITLE
Fix layout of "Show all questions from this user" page

### DIFF
--- a/app/assets/stylesheets/components/_question.scss
+++ b/app/assets/stylesheets/components/_question.scss
@@ -21,6 +21,7 @@
     @include media-breakpoint-up('sm') {
       position: sticky;
       top: $navbar-height;
+      z-index: 1;
     }
   }
 }

--- a/app/views/moderation/questions/_header.html.haml
+++ b/app/views/moderation/questions/_header.html.haml
@@ -1,4 +1,4 @@
-.card.question--fixed{ class: hidden ? 'question--hidden' : '', tabindex: hidden ? -1 : '', aria: { hidden: hidden } }
+.card.question--sticky
   .container
     .card-body
       .d-flex

--- a/app/views/moderation/questions/show.html.haml
+++ b/app/views/moderation/questions/show.html.haml
@@ -1,8 +1,7 @@
 - provide(:title, generate_title(t(".title", author_identifier: params[:author_identifier].truncate(32))))
 
-= render "header", author_identifier: params[:author_identifier], hidden: false
-= render "header", author_identifier: params[:author_identifier], hidden: true
+= render "header", author_identifier: params[:author_identifier]
 
-.container-lg.container--main
+.container-lg.question-page
   - @questions.each do |q|
     = render "shared/question", q:, type: "moderation"


### PR DESCRIPTION
Fixes #1436 

Fixes the issue of the header being duplicated on the "Show all questions from user" page. And additionally also found an issue with the z-index of the sticky question header (which is also used on the question overview)

**Testing:**
* Rebuild stylesheets (`yarn run build:css`)
* Go to `[host]/moderation/questions/justask`