### PR TITLE
Add empty hints to list views

### DIFF
--- a/app/views/inbox/show.html.haml
+++ b/app/views/inbox/show.html.haml
@@ -3,7 +3,7 @@
     = render "inbox/entry", i:
 
   - if @inbox.empty?
-    %p.empty= t(".empty")
+    = render "shared/empty", type: "inbox"
 
 - if @more_data_available
   .d-flex.justify-content-center#paginator

--- a/app/views/moderation/inbox/_header.html.haml
+++ b/app/views/moderation/inbox/_header.html.haml
@@ -1,4 +1,4 @@
-.card.question--fixed{ class: hidden ? 'question--hidden' : '', tabindex: hidden ? -1 : '', aria: { hidden: hidden } }
+.card.question--sticky
   .container
     .card-body
       .d-flex

--- a/app/views/moderation/inbox/index.html.haml
+++ b/app/views/moderation/inbox/index.html.haml
@@ -2,8 +2,11 @@
 
 = render "header", user: @user
 
-.container-lg.container--main
+.container-lg.question-page
   #entries
+    - if @inboxes.empty?
+      = render "shared/empty", icon: "fa fa-inbox", translation_key: ".moderation.inbox"
+
     - @inboxes.each do |i|
       = render "inbox/entry", i: i
 

--- a/app/views/moderation/inbox/index.html.haml
+++ b/app/views/moderation/inbox/index.html.haml
@@ -1,7 +1,6 @@
 - provide(:title, generate_title(t(".title", user: @user.screen_name)))
 
-= render "header", user: @user, hidden: false
-= render "header", user: @user, hidden: true
+= render "header", user: @user
 
 .container-lg.container--main
   #entries

--- a/app/views/moderation/reports/index.html.haml
+++ b/app/views/moderation/reports/index.html.haml
@@ -1,4 +1,7 @@
 #reports
+  - if @reports.empty?
+    = render "shared/empty", icon: "fa-regular fa-smile-beam", translation_key: ".moderation.reports"
+
   - @reports.each do |r|
     = render "moderation/moderationbox", report: r
 

--- a/app/views/question/show.html.haml
+++ b/app/views/question/show.html.haml
@@ -7,6 +7,9 @@
   #answers{ data: { controller: "navigation" } }
     %button.d-none{ data: { hotkey: "j", action: "navigation#down" } }
     %button.d-none{ data: { hotkey: "k", action: "navigation#up" } }
+    - if @answers.empty?
+      = render "shared/empty", icon: "fa-regular fa-comments", translation_key: ".question"
+
     - @answers.each do |a|
       = render "answerbox", a:, show_question: false
 

--- a/app/views/shared/_empty.html.haml
+++ b/app/views/shared/_empty.html.haml
@@ -1,0 +1,34 @@
+- type ||= nil
+.card{ class: type == "inbox" ? "empty" : nil }
+  .card-body.py-5.text-center
+    - if type == "timeline"
+      %p.mb-3
+        %i.fa-regular.fa-comments.icon--showcase.text-muted
+      %h3= t(".timeline.heading")
+      %p= t(".timeline.text")
+      %p
+        %a.btn.btn-primary{ href: inbox_path }= t(".timeline.actions.inbox")
+        %a.btn.btn-default{ href: public_timeline_path }= t(".timeline.actions.public")
+    - elsif type == "inbox"
+      %p.mb-3
+        %i.fa.fa-inbox.icon--showcase.text-muted
+      %h3= t(".inbox.heading")
+      %p= t(".inbox.text")
+      .d-block.d-sm-flex.justify-content-center
+        = button_to inbox_create_path, class: "btn btn-info me-auto" do
+          = t("inbox.actions.questions.button")
+        .button-group.ms-1
+          %button.btn.btn-default{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
+            %i.fa.fa-fw.fa-share-alt
+            %span= t("inbox.actions.share.heading")
+          .dropdown-menu.dropdown-menu-end{ role: :menu }
+            %a.dropdown-item{ href: "https://twitter.com/intent/tweet?text=Ask%20me%20anything%21&url=#{user_url(current_user)}", target: "_blank" }
+              %i.fa.fa-fw.fa-twitter
+              = t("inbox.actions.share.button", service: "Twitter")
+            %a.dropdown-item{ href: "https://www.tumblr.com/share/link?url=#{user_url(current_user)}&name=Ask%20me%20anything%21", target: "_blank" }
+              %i.fa.fa-fw.fa-tumblr
+              = t("inbox.actions.share.button", service: "Tumblr")
+    - else
+      %p.mb-3
+        %i.icon--showcase.text-muted{ class: icon }
+      %p= t(translation_key)

--- a/app/views/timeline/timeline.html.haml
+++ b/app/views/timeline/timeline.html.haml
@@ -1,6 +1,9 @@
 #timeline{ data: { controller: "navigation" } }
   %button.d-none{ data: { hotkey: "j", action: "navigation#down" } }
   %button.d-none{ data: { hotkey: "k", action: "navigation#up" } }
+  - if @timeline.empty?
+    = render "shared/empty", type: "timeline"
+
   - @timeline.each do |answer|
     = render "answerbox", a: answer
 

--- a/app/views/user/questions.html.haml
+++ b/app/views/user/questions.html.haml
@@ -1,4 +1,7 @@
 #questions
+  - if @questions.empty?
+    = render "shared/empty", icon: "fa-regular fa-comment", translation_key: ".user.questions"
+
   - @questions.each do |q|
     = render 'shared/question', q: q, type: nil
 

--- a/app/views/user/show.html.haml
+++ b/app/views/user/show.html.haml
@@ -7,6 +7,9 @@
         = render "answerbox", a:
 
     #answers
+      - if @answers.empty?
+        = render "shared/empty", icon: "fa-regular fa-comments", translation_key: ".user.answers"
+
       - @answers.each do |a|
         = render "answerbox", a:
 

--- a/app/views/user/show_follow.html.haml
+++ b/app/views/user/show_follow.html.haml
@@ -1,3 +1,6 @@
+- if @users.empty?
+  = render "shared/empty", icon: "fa-regular fa-user", translation_key: ".user.#{type}"
+
 .row.row-cols-1.row-cols-sm-2.row-cols-md-3#users
   - @users.each do |user|
     .col.pb-3

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -573,6 +573,11 @@ en:
         show: "Show full question"
         hide: "Hide full question"
     empty:
+      user:
+        answers: "This user hasn't answered any questions yet."
+        questions: "This user hasn't asked any questions yet."
+        follower: "This user has no followers."
+        friend: "This user is not following anyone."
     formatting:
       body_html: |
         <p>%{app_name} uses <b>Markdown</b> for formatting</p>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -581,6 +581,9 @@ en:
       moderation:
         reports: "There are no open reports right now!"
         inbox: "This users inbox is empty."
+      inbox:
+        heading: "Your inbox is empty!"
+        text: "To start answering, generate a question or share your profile on other sites to get questions."
     formatting:
       body_html: |
         <p>%{app_name} uses <b>Markdown</b> for formatting</p>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -581,6 +581,7 @@ en:
       moderation:
         reports: "There are no open reports right now!"
         inbox: "This users inbox is empty."
+      question: "No one answered this question yet."
       timeline:
         heading: "Your feed is empty!"
         text: "Start answering questions or follow some people to fill your feed with answers."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -578,6 +578,9 @@ en:
         questions: "This user hasn't asked any questions yet."
         follower: "This user has no followers."
         friend: "This user is not following anyone."
+      moderation:
+        reports: "There are no open reports right now!"
+        inbox: "This users inbox is empty."
     formatting:
       body_html: |
         <p>%{app_name} uses <b>Markdown</b> for formatting</p>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -581,6 +581,12 @@ en:
       moderation:
         reports: "There are no open reports right now!"
         inbox: "This users inbox is empty."
+      timeline:
+        heading: "Your feed is empty!"
+        text: "Start answering questions or follow some people to fill your feed with answers."
+        actions:
+          inbox: "Go to your inbox"
+          public: "Go to the public timeline"
       inbox:
         heading: "Your inbox is empty!"
         text: "To start answering, generate a question or share your profile on other sites to get questions."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -572,6 +572,7 @@ en:
       question:
         show: "Show full question"
         hide: "Hide full question"
+    empty:
     formatting:
       body_html: |
         <p>%{app_name} uses <b>Markdown</b> for formatting</p>

--- a/spec/views/inbox/show.html.haml_spec.rb
+++ b/spec/views/inbox/show.html.haml_spec.rb
@@ -18,9 +18,9 @@ describe "inbox/show.html.haml", type: :view do
 
     it "displays an 'inbox is empty' message" do
       html = Nokogiri::HTML.parse(rendered)
-      selector = "p.empty"
+      selector = "div.card.empty"
       expect(rendered).to have_css(selector)
-      expect(html.css(selector).text.strip).to eq "Nothing to see here."
+      expect(html.css(selector).text.strip).to include "Your inbox is empty!"
     end
   end
 


### PR DESCRIPTION
A lot of list views simply are empty if no content is available. That's super bad for user experience and now finally fixed.

Previews can be found in [this post](https://desu.social/@pixel/111557677638543534)

Hints have been added to following views:
* All user pages (answers/questions/following/followers)
* The main timeline
* The inbox
* Question pages
* Moderation views (inbox/reports)