### PR TITLE
Fix anonymous block model associations

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,6 +2,7 @@ class Question < ApplicationRecord
   include Question::AnswerMethods
 
   belongs_to :user, optional: true
+  has_many :anonymous_blocks, dependent: :nullify
   has_many :answers, dependent: :destroy
   has_many :inboxes, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,9 +54,9 @@ class User < ApplicationRecord
                           dependent:   :nullify
 
   has_many :anonymous_blocks, dependent: :destroy_async
-  has_many :passive_anonymous_blocks, class_name: "AnonymousBlock",
+  has_many :passive_anonymous_blocks, class_name:  "AnonymousBlock",
                                       foreign_key: "target_user_id",
-                                      dependent: :nullify
+                                      dependent:   :nullify
 
   SCREEN_NAME_REGEX = /\A[a-zA-Z0-9_]+\z/
   WEBSITE_REGEX = /https?:\/\/([A-Za-z.-]+)\/?(?:.*)/i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,6 @@ class User < ApplicationRecord
   has_many :lists, dependent: :destroy_async
   has_many :list_memberships, class_name: "ListMember", dependent: :destroy_async
   has_many :mute_rules, dependent: :destroy_async
-  has_many :anonymous_blocks, dependent: :destroy_async
 
   has_many :subscriptions, dependent: :destroy_async
   has_many :totp_recovery_codes, dependent: :destroy_async
@@ -53,6 +52,11 @@ class User < ApplicationRecord
   has_many :banned_users, class_name:  "UserBan",
                           foreign_key: "banned_by_id",
                           dependent:   :nullify
+
+  has_many :anonymous_blocks, dependent: :destroy_async
+  has_many :passive_anonymous_blocks, class_name: "AnonymousBlock",
+                                      foreign_key: "target_user_id",
+                                      dependent: :nullify
 
   SCREEN_NAME_REGEX = /\A[a-zA-Z0-9_]+\z/
   WEBSITE_REGEX = /https?:\/\/([A-Za-z.-]+)\/?(?:.*)/i


### PR DESCRIPTION
Fixes #1563

This also covers the rare (practically impossible) case that a user manages to delete their anonymous question. The optional fields are now properly nulled when the associated record is removed and doesn't prevent deletion of either in return.

**Testing:**
* Ask an anonymous question, with an account
* On the target account, block the anonymous question
* Try deleting the first account, it should work