### PR TITLE
Add more generic implementation of inbox filtering

### DIFF
--- a/app/models/inbox_filter.rb
+++ b/app/models/inbox_filter.rb
@@ -5,10 +5,10 @@ class InboxFilter
 
   define_cursor_paginator :cursored_results, :results
 
-  KEYS = %i(
+  KEYS = %i[
     author
     anonymous
-  ).freeze
+  ].freeze
 
   attr_reader :params, :user
 
@@ -36,10 +36,10 @@ class InboxFilter
     case key.to_s
     when "author"
       @user.inboxes.joins(question: [:user])
-                   .where(questions: { users: { screen_name: value }, author_is_anonymous: false })
+           .where(questions: { users: { screen_name: value }, author_is_anonymous: false })
     when "anonymous"
       @user.inboxes.joins(:question)
-                   .where(questions: { author_is_anonymous: true })
+           .where(questions: { author_is_anonymous: true })
     end
   end
 end

--- a/app/models/inbox_filter.rb
+++ b/app/models/inbox_filter.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class InboxFilter
+  include CursorPaginatable
+
+  define_cursor_paginator :cursored_results, :results
+
+  KEYS = %i(
+    author
+    anonymous
+  ).freeze
+
+  attr_reader :params, :user
+
+  def initialize(user, params)
+    @user = user
+    @params = params
+  end
+
+  def results
+    scope = @user.inboxes
+                 .includes(:question, user: :profile)
+                 .order(:created_at)
+                 .reverse_order
+
+    params.each do |key, value|
+      scope.merge!(scope_for(key, value)) if value.present?
+    end
+
+    scope
+  end
+
+  private
+
+  def scope_for(key, value)
+    case key.to_s
+    when "author"
+      @user.inboxes.joins(question: [:user])
+                   .where(questions: { users: { screen_name: value }, author_is_anonymous: false })
+    when "anonymous"
+      @user.inboxes.joins(:question)
+                   .where(questions: { author_is_anonymous: true })
+    end
+  end
+end

--- a/spec/controllers/inbox_controller_spec.rb
+++ b/spec/controllers/inbox_controller_spec.rb
@@ -103,7 +103,7 @@ describe InboxController, type: :controller do
               more_data_available: true,
               inbox_count:         16,
               delete_id:           "ib-delete-all",
-              disabled:            nil
+              disabled:            nil,
             }
           end
         end
@@ -119,7 +119,7 @@ describe InboxController, type: :controller do
                 more_data_available: false,
                 inbox_count:         16,
                 delete_id:           "ib-delete-all",
-                disabled:            nil
+                disabled:            nil,
               }
             end
           end
@@ -136,8 +136,8 @@ describe InboxController, type: :controller do
             question: FactoryBot.create(
               :question,
               user:                unrelated_user,
-              author_is_anonymous: false
-            )
+              author_is_anonymous: false,
+            ),
           )
         end
         let!(:generic_inbox_entry2) { Inbox.create(user:, question: FactoryBot.create(:question)) }
@@ -155,7 +155,7 @@ describe InboxController, type: :controller do
                   inbox:               [],
                   inbox_last_id:       nil,
                   more_data_available: false,
-                  inbox_count:         0
+                  inbox_count:         0,
                 }
               end
             end
@@ -168,8 +168,8 @@ describe InboxController, type: :controller do
                 question: FactoryBot.create(
                   :question,
                   user:                other_user,
-                  author_is_anonymous: true
-                )
+                  author_is_anonymous: true,
+                ),
               )
             end
 
@@ -180,7 +180,7 @@ describe InboxController, type: :controller do
                   inbox:               [],
                   inbox_last_id:       nil,
                   more_data_available: false,
-                  inbox_count:         0
+                  inbox_count:         0,
                 }
               end
             end
@@ -193,8 +193,8 @@ describe InboxController, type: :controller do
                 question: FactoryBot.create(
                   :question,
                   user:                other_user,
-                  author_is_anonymous: false
-                )
+                  author_is_anonymous: false,
+                ),
               )
             end
             let!(:anonymous_inbox_entry) do
@@ -203,8 +203,8 @@ describe InboxController, type: :controller do
                 question: FactoryBot.create(
                   :question,
                   user:                other_user,
-                  author_is_anonymous: true
-                )
+                  author_is_anonymous: true,
+                ),
               )
             end
 
@@ -216,7 +216,7 @@ describe InboxController, type: :controller do
                   more_data_available: false,
                   inbox_count:         1,
                   delete_id:           "ib-delete-all-author",
-                  disabled:            nil
+                  disabled:            nil,
                 }
               end
             end
@@ -232,8 +232,8 @@ describe InboxController, type: :controller do
             question: FactoryBot.create(
               :question,
               user:                other_user,
-              author_is_anonymous: false
-            )
+              author_is_anonymous: false,
+            ),
           )
         end
 
@@ -249,7 +249,7 @@ describe InboxController, type: :controller do
             {
               inbox:               [*inbox_entry_fillers.reverse],
               more_data_available: false,
-              inbox_count:         9
+              inbox_count:         9,
             }
           end
         end


### PR DESCRIPTION
The way author filtering works is kinda messy, so adding additional filters to that would make the entire code even more convoluted. I decided to look into how Mastodon does filtering for some of their moderation views and adjusted that implementation for our use case, resulting in this PR.

This fixes #426 (without any UI for it, however).