### PR TITLE
Use `attr_accessor` for `Answer` object properties

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,7 +1,7 @@
 class Answer < ApplicationRecord
   extend Answer::TimelineMethods
 
-  attr_writer :has_reacted, :is_subscribed
+  attr_accessor :has_reacted, :is_subscribed
 
   belongs_to :user, counter_cache: :answered_count
   belongs_to :question, counter_cache: :answer_count


### PR DESCRIPTION
The usage of `attr_writer` for `has_reacted` and `has_subscribed` on `Answer` caused access issues in non-inbox answering of questions, because these properties were not accessible in those cases.