### PR TITLE
Add scheduled job to clean up orphaned inbox entries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "sentry-ruby"
 gem "sentry-sidekiq"
 
 gem "sidekiq", "< 7" # remove version constraint once are ready to upgrade https://github.com/mperham/sidekiq/blob/main/docs/7.0-Upgrade.md
+gem "sidekiq-scheduler"
 
 gem "questiongenerator", "~> 1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.12.0)
+    et-orbi (1.2.7)
+      tzinfo
     excon (0.109.0)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
@@ -195,6 +197,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    fugit (1.9.0)
+      et-orbi (~> 1, >= 1.2.7)
+      raabro (~> 1.4)
     glob (0.4.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -306,6 +311,7 @@ GEM
     pundit (2.3.1)
       activesupport (>= 3.0.0)
     questiongenerator (1.1.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.8)
     rack-test (2.1.0)
@@ -426,6 +432,8 @@ GEM
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     rubyzip (2.3.2)
+    rufus-scheduler (3.9.1)
+      fugit (~> 1.1, >= 1.1.6)
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -451,6 +459,10 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-scheduler (5.0.3)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 6, < 8)
+      tilt (>= 1.4.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -582,6 +594,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers (~> 6.0)
   sidekiq (< 7)
+  sidekiq-scheduler
   simplecov
   simplecov-cobertura
   simplecov-json

--- a/app/workers/scheduler/inbox_cleanup_scheduler.rb
+++ b/app/workers/scheduler/inbox_cleanup_scheduler.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Scheduler::InboxCleanupScheduler
+  include Sidekiq::Worker
+
+  sidekiq_options retry: false
+
+  def perform
+    orphaned_entries = Inbox.where(question_id: nil).includes(:user)
+    orphaned_entries.each do |inbox|
+      logger.info "Deleting orphaned inbox entry #{inbox.id} from user #{inbox.user.id}"
+      inbox.destroy
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,4 +13,11 @@ production:
   - question
   - export
   - push_notification
+  - scheduler
 
+:scheduler:
+  :schedule:
+    inbox_cleanup:
+      every: 1m
+      class: Scheduler::InboxCleanupScheduler
+      queue: scheduler

--- a/spec/workers/scheduler/inbox_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/inbox_cleanup_scheduler_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Scheduler::InboxCleanupScheduler do
+  let(:user) { FactoryBot.create(:user) }
+  let(:inbox) { FactoryBot.create(:inbox, user:) }
+
+  describe "#perform" do
+    before do
+      inbox.question_id = nil
+      inbox.save(validate: false)
+    end
+
+    subject { described_class.new.perform }
+
+    it "should delete orphaned inbox entries" do
+      expect { subject }
+        .to(
+          change { Inbox.where(question_id: nil).count }
+            .from(1)
+            .to(0),
+        )
+    end
+  end
+end


### PR DESCRIPTION
Feature and bugfix in one PR!

This PR adds `sidekiq-scheduler` and our first scheduled job to go along with it, `InboxCleanupScheduler`. 

This job runs every minute and cleans up orphaned inbox entries. This is a bug fix to prevent broken inboxes due to "somewhere down the line" deletion of something causing this behaviour. There is no case where this should happen, as to why the test case for this scheduler even has to disable validations on saving the broken record that is scheduled for deletion.

@nilsding this works fine locally without any change to the setup, but I'm not sure about how this ends up working with our deployment and what changes need to be made to accommodate this.