### PR TITLE
Disallow anonymously blocking yourself

### DIFF
--- a/app/views/actions/_question.html.haml
+++ b/app/views/actions/_question.html.haml
@@ -8,9 +8,10 @@
       %i.fa.fa-fw.fa-exclamation-triangle
       = t("voc.report")
   - if question.anonymous? && !question.generated?
-    = button_to anonymous_block_path, method: :post, params: { question: question.id }, class: "dropdown-item" do
-      %i.fa.fa-fw.fa-minus-circle
-      = t("voc.block")
+    - unless question.user == current_user
+      = button_to anonymous_block_path, method: :post, params: { question: question.id }, class: "dropdown-item" do
+        %i.fa.fa-fw.fa-minus-circle
+        = t("voc.block")
     - if current_user.mod?
       = button_to anonymous_block_path, method: :post, params: { question: question.id, global: true }, class: "dropdown-item" do
         %i.fas.fa-fw.fa-user-slash


### PR DESCRIPTION
With #1563 and several cases of anonymous blocks causing this problem I noticed that one case that prevented account deletion was someone anonymous blocking themselves.

This is a behaviour that shouldn't be possible (it doesn't even make sense), so this prevents it.