### PR TITLE
Install `web-push` gem as a replacement for `webpush`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "mini_magick"
 gem "oj"
 gem "rpush"
 gem "rqrcode"
+gem "web-push"
 
 gem "rolify", "~> 6.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,9 @@ GEM
       method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    web-push (3.0.1)
+      jwt (~> 2.0)
+      openssl (~> 3.0)
     webpush (1.1.0)
       hkdf (~> 0.2)
       jwt (~> 2.0)
@@ -604,6 +607,7 @@ DEPENDENCIES
   turbo-rails
   twitter-text
   view_component
+  web-push
 
 BUNDLED WITH
    2.5.5

--- a/db/migrate/20220909220449_add_webpush_app.rb
+++ b/db/migrate/20220909220449_add_webpush_app.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "webpush"
+require "web-push"
 
 class AddWebpushApp < ActiveRecord::Migration[6.1]
   def up
-    vapid_keypair = Webpush.generate_key.to_hash
+    vapid_keypair = WebPush.generate_key.to_hash
     app = Rpush::Webpush::App.new
     app.name = "webpush"
     app.certificate = vapid_keypair.merge(subject: APP_CONFIG.fetch("contact_email")).to_json


### PR DESCRIPTION
_Fixes #1446_

Technically it isn't a full replacement of the `webpush` gem, but it replaces the crucial part of the `vapid_key` generation in the migration, which is broken because of OpenSSL 3. Once `rpush` decides to switch to this (or an equivalent) fork, we can remove this again.

But for now this is required to make installations from scratch work again.