### PR TITLE
Add target user to reports

### DIFF
--- a/app/controllers/ajax/report_controller.rb
+++ b/app/controllers/ajax/report_controller.rb
@@ -36,13 +36,7 @@ class Ajax::ReportController < AjaxController
       return
     end
 
-    target_user = if object.class.to_s == "User"
-                    object
-                  elsif object.respond_to? :user
-                    object.user
-                  end
-
-    current_user.report object, target_user, params[:reason]
+    current_user.report object, params[:reason]
 
     @response[:status] = :okay
     @response[:message] = t(".success", parameter: params[:type].titleize)

--- a/app/controllers/ajax/report_controller.rb
+++ b/app/controllers/ajax/report_controller.rb
@@ -36,7 +36,13 @@ class Ajax::ReportController < AjaxController
       return
     end
 
-    current_user.report object, params[:reason]
+    target_user = if object.class.to_s == "User"
+                    object
+                  elsif object.respond_to? :user
+                    object.user
+                  end
+
+    current_user.report object, target_user, params[:reason]
 
     @response[:status] = :okay
     @response[:message] = t(".success", parameter: params[:type].titleize)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,5 +1,6 @@
 class Report < ApplicationRecord
   belongs_to :user
+  belongs_to :target_user, class_name: "User", optional: true
   validates :type, presence: true
   validates :target_id, presence: true
   validates :user_id, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,10 +148,10 @@ class User < ApplicationRecord
   def admin? = has_cached_role?(:administrator)
 
   # region stuff used for reporting/moderation
-  def report(object, reason = nil)
-    existing = Report.find_by(type: "Reports::#{object.class}", target_id: object.id, user_id: id, deleted: false)
+  def report(object, target_user = nil, reason = nil)
+    existing = Report.find_by(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, deleted: false)
     if existing.nil?
-      Report.create(type: "Reports::#{object.class}", target_id: object.id, user_id: id, reason:)
+      Report.create(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, reason:)
     elsif !reason.nil? && reason.length.positive?
       existing.append_reason(reason)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
 
   # region stuff used for reporting/moderation
   def report(object, reason = nil)
-    target_user = if object.class.to_s == "User"
+    target_user = if object.instance_of?(::User)
                     object
                   elsif object.respond_to? :user
                     object.user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,7 +148,13 @@ class User < ApplicationRecord
   def admin? = has_cached_role?(:administrator)
 
   # region stuff used for reporting/moderation
-  def report(object, target_user = nil, reason = nil)
+  def report(object, reason = nil)
+    target_user = if object.class.to_s == "User"
+                    object
+                  elsif object.respond_to? :user
+                    object.user
+                  end
+
     existing = Report.find_by(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, deleted: false)
     if existing.nil?
       Report.create(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, reason:)

--- a/db/migrate/20240123182422_add_target_user_to_reports.rb
+++ b/db/migrate/20240123182422_add_target_user_to_reports.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddTargetUserToReports < ActiveRecord::Migration[7.0]
+  def up
+    add_reference :reports, :target_user, null: true, foreign_key: false
+
+    execute <<~SQL.squish
+      UPDATE reports
+      SET target_user_id = users.id
+      FROM users
+      WHERE users.id = reports.target_id AND reports.type = 'Reports::User'
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE reports
+      SET target_user_id = users.id
+      FROM users, comments
+      WHERE users.id = comments.user_id AND comments.id = reports.target_id AND reports.type = 'Reports::Comment'
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE reports
+      SET target_user_id = users.id
+      FROM users, answers
+      WHERE users.id = answers.user_id AND answers.id = reports.target_id AND reports.type = 'Reports::Answer'
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE reports
+      SET target_user_id = users.id
+      FROM users, questions
+      WHERE users.id = questions.user_id AND questions.id = reports.target_id AND reports.type = 'Reports::Question'
+    SQL
+  end
+
+  def down
+    remove_reference :reports, :target_user, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/migrate/20240123182422_add_target_user_to_reports.rb
+++ b/db/migrate/20240123182422_add_target_user_to_reports.rb
@@ -34,6 +34,6 @@ class AddTargetUserToReports < ActiveRecord::Migration[7.0]
   end
 
   def down
-    remove_reference :reports, :target_user, null: true, foreign_key: { to_table: :users }
+    remove_reference :reports, :target_user, null: true, foreign_key: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_20_100445) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_23_182422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,11 +28,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_100445) do
   end
 
   create_table "anonymous_blocks", force: :cascade do |t|
+    t.bigint "user_id"
     t.string "identifier"
+    t.bigint "question_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "question_id"
-    t.bigint "user_id"
     t.bigint "target_user_id"
     t.index ["identifier"], name: "index_anonymous_blocks_on_identifier"
     t.index ["question_id"], name: "index_anonymous_blocks_on_question_id"
@@ -95,10 +95,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_100445) do
   end
 
   create_table "mute_rules", id: :bigint, default: -> { "gen_timestamp_id('mute_rules'::text)" }, force: :cascade do |t|
+    t.bigint "user_id"
     t.string "muted_phrase"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.bigint "user_id"
     t.index ["user_id"], name: "index_mute_rules_on_user_id"
   end
 
@@ -173,6 +173,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_100445) do
     t.datetime "updated_at", precision: nil
     t.boolean "deleted", default: false
     t.string "reason"
+    t.bigint "target_user_id"
+    t.index ["target_user_id"], name: "index_reports_on_target_user_id"
     t.index ["type", "target_id"], name: "index_reports_on_type_and_target_id"
     t.index ["user_id", "created_at"], name: "index_reports_on_user_id_and_created_at"
   end


### PR DESCRIPTION
Fixes #1561

Adds a `target_user(_id)` field to reports, storing the target user, regardless of the report being specifically for a user, answer, question, etc. Includes a migration for currently existing reports to fill the field and of course extending the logic of `Ajax::ReportController#create` to pass the target user into created reports.

The reference field does not include a foreign key and is wholly optional, so reports don't block the account deletion (like it was the case with anonymous blocks).