### PR TITLE
Add missing expire times to cache keys

### DIFF
--- a/app/models/user/ban_methods.rb
+++ b/app/models/user/ban_methods.rb
@@ -6,7 +6,7 @@ module User::BanMethods
   end
 
   def banned?
-    Rails.cache.fetch("#{cache_key}/banned") do
+    Rails.cache.fetch("#{cache_key}/banned", expires_in: 6.hours) do
       bans.current.count.positive?
     end
   end

--- a/app/models/user/inbox_methods.rb
+++ b/app/models/user/inbox_methods.rb
@@ -14,7 +14,7 @@ module User::InboxMethods
   end
 
   def unread_inbox_count
-    Rails.cache.fetch(inbox_cache_key) do
+    Rails.cache.fetch(inbox_cache_key, expires_in: 12.hours) do
       count = Inbox.where(new: true, user_id: id).count(:id)
 
       # Returning +nil+ here in order to not display a counter

--- a/app/models/user/notification_methods.rb
+++ b/app/models/user/notification_methods.rb
@@ -2,7 +2,7 @@
 
 module User::NotificationMethods
   def unread_notification_count
-    Rails.cache.fetch(notification_cache_key) do
+    Rails.cache.fetch(notification_cache_key, expires_in: 12.hours) do
       count = Notification.for(self).where(new: true).count(:id)
 
       # Returning +nil+ here in order to not display a counter

--- a/app/views/navigation/_desktop.html.haml
+++ b/app/views/navigation/_desktop.html.haml
@@ -26,7 +26,7 @@
             = render "navigation/icons/notifications", notification_count:
         .dropdown-menu.dropdown-menu-end.notification-dropdown
           %turbo-frame#notifications-dropdown-list
-            - cache current_user.notification_dropdown_cache_key do
+            - cache current_user.notification_dropdown_cache_key, expires_in: 12.hours do
               - notifications = Notification.for(current_user).where(new: true).includes([:target]).limit(4)
               = render "navigation/dropdown/notifications", notifications:, size: "desktop"
       %li.nav-item.d-none.d-sm-block{ data: { bs_toggle: 'tooltip', bs_placement: 'bottom' }, title: t('.ask_question') }


### PR DESCRIPTION
We noticed our Redis filling up quite often recently and one reason being a lot of specific cache keys being present forever.

These might have data that technically doesn't change, or is updated through `touch`es, but the old keys remain. Thus we are setting a relatively high expire time of 12 hours on those.

I'm setting a lower one on the highest frequented one, `users/:id/banned`, of 6 hours. Because this key is created for every profile link that's rendered on a page, filling up insanely quickly.