### PR TITLE
Rename inboxes to inbox entries

### DIFF
--- a/app/controllers/ajax/answer_controller.rb
+++ b/app/controllers/ajax/answer_controller.rb
@@ -13,7 +13,7 @@ class Ajax::AnswerController < AjaxController
     inbox = (params[:inbox] == "true")
 
     if inbox
-      inbox_entry = Inbox.find(params[:id])
+      inbox_entry = InboxEntry.find(params[:id])
 
       unless current_user == inbox_entry.user
         @response[:status] = :fail
@@ -59,7 +59,7 @@ class Ajax::AnswerController < AjaxController
       return
     end
 
-    Inbox.create!(user: answer.user, question: answer.question, new: true, returning: true) if answer.user == current_user
+    InboxEntry.create!(user: answer.user, question: answer.question, new: true, returning: true) if answer.user == current_user
     answer.destroy
 
     @response[:status] = :okay

--- a/app/controllers/ajax/inbox_controller.rb
+++ b/app/controllers/ajax/inbox_controller.rb
@@ -44,8 +44,8 @@ class Ajax::InboxController < AjaxController
   def remove_all_author
     begin
       @target_user = User.where('LOWER(screen_name) = ?', params[:author].downcase).first!
-      @inbox = current_user.inboxes.joins(:question)
-                                   .where(questions: { user_id: @target_user.id, author_is_anonymous: false })
+      @inbox = current_user.inbox_entries.joins(:question)
+                                         .where(questions: { user_id: @target_user.id, author_is_anonymous: false })
       @inbox.each { |i| i.remove }
     rescue => e
       Sentry.capture_exception(e)

--- a/app/controllers/ajax/inbox_controller.rb
+++ b/app/controllers/ajax/inbox_controller.rb
@@ -2,7 +2,7 @@ class Ajax::InboxController < AjaxController
   def remove
     params.require :id
 
-    inbox = Inbox.find(params[:id])
+    inbox = InboxEntry.find(params[:id])
 
     unless current_user == inbox.user
       @response[:status] = :fail
@@ -28,7 +28,7 @@ class Ajax::InboxController < AjaxController
     raise unless user_signed_in?
 
     begin
-      Inbox.where(user: current_user).each { |i| i.remove }
+      InboxEntry.where(user: current_user).each { |i| i.remove }
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :err

--- a/app/controllers/ajax/inbox_controller.rb
+++ b/app/controllers/ajax/inbox_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Ajax::InboxController < AjaxController
   def remove
     params.require :id
@@ -28,7 +30,7 @@ class Ajax::InboxController < AjaxController
     raise unless user_signed_in?
 
     begin
-      InboxEntry.where(user: current_user).each { |i| i.remove }
+      InboxEntry.where(user: current_user).find_each(&:remove)
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :err
@@ -43,10 +45,10 @@ class Ajax::InboxController < AjaxController
 
   def remove_all_author
     begin
-      @target_user = User.where('LOWER(screen_name) = ?', params[:author].downcase).first!
+      @target_user = User.where("LOWER(screen_name) = ?", params[:author].downcase).first!
       @inbox = current_user.inbox_entries.joins(:question)
-                                         .where(questions: { user_id: @target_user.id, author_is_anonymous: false })
-      @inbox.each { |i| i.remove }
+                           .where(questions: { user_id: @target_user.id, author_is_anonymous: false })
+      @inbox.each(&:remove)
     rescue => e
       Sentry.capture_exception(e)
       @response[:status] = :err

--- a/app/controllers/anonymous_block_controller.rb
+++ b/app/controllers/anonymous_block_controller.rb
@@ -20,8 +20,8 @@ class AnonymousBlockController < ApplicationController
       target_user: question.user
     )
 
-    inbox_id = question.inboxes.first&.id
-    question.inboxes.first&.destroy
+    inbox_id = question.inbox_entries.first&.id
+    question.inbox_entries.first&.destroy
 
     respond_to do |format|
       format.turbo_stream do

--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -23,7 +23,7 @@ class InboxController < ApplicationController
                                 author_identifier:   "justask",
                                 user:                current_user)
 
-    inbox = Inbox.create!(user: current_user, question_id: question.id, new: true)
+    inbox = InboxEntry.create!(user: current_user, question_id: question.id, new: true)
     increment_metric
 
     respond_to do |format|

--- a/app/controllers/moderation/inbox_controller.rb
+++ b/app/controllers/moderation/inbox_controller.rb
@@ -8,7 +8,7 @@ class Moderation::InboxController < ApplicationController
     @inboxes = @user.cursored_inbox(last_id: params[:last_id])
     @inbox_last_id = @inboxes.map(&:id).min
     @more_data_available = !@user.cursored_inbox(last_id: @inbox_last_id, size: 1).count.zero?
-    @inbox_count = @user.inboxes.count
+    @inbox_count = @user.inbox_entries.count
 
     respond_to do |format|
       format.html

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -36,7 +36,7 @@ class Answer < ApplicationRecord
   SHORT_ANSWER_MAX_LENGTH = 640
 
   after_create do
-    Inbox.where(user: self.user, question: self.question).destroy_all
+    InboxEntry.where(user: self.user, question: self.question).destroy_all
     user.touch :inbox_updated_at # rubocop:disable Rails/SkipsModelValidations
 
     Notification.notify self.question.user, self unless self.question.user == self.user or self.question.user.nil?

--- a/app/models/inbox_entry.rb
+++ b/app/models/inbox_entry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Inbox < ApplicationRecord
+class InboxEntry < ApplicationRecord
   belongs_to :user, touch: :inbox_updated_at
   belongs_to :question
 

--- a/app/models/inbox_filter.rb
+++ b/app/models/inbox_filter.rb
@@ -22,7 +22,7 @@ class InboxFilter
   end
 
   def results
-    return Inbox.none unless valid_params?
+    return InboxEntry.none unless valid_params?
 
     scope = @user.inboxes
                  .includes(:question, user: :profile)

--- a/app/models/inbox_filter.rb
+++ b/app/models/inbox_filter.rb
@@ -24,7 +24,7 @@ class InboxFilter
   def results
     return InboxEntry.none unless valid_params?
 
-    scope = @user.inboxes
+    scope = @user.inbox_entries
                  .includes(:question, user: :profile)
                  .order(:created_at)
                  .reverse_order
@@ -45,10 +45,10 @@ class InboxFilter
   def scope_for(key, value)
     case key.to_s
     when "author"
-      @user.inboxes.joins(question: [:user])
+      @user.inbox_entries.joins(question: [:user])
            .where(questions: { users: { screen_name: value }, author_is_anonymous: false })
     when "anonymous"
-      @user.inboxes.joins(:question)
+      @user.inbox_entries.joins(:question)
            .where(questions: { author_is_anonymous: true })
     end
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Question < ApplicationRecord
   include Question::AnswerMethods
 
@@ -11,7 +13,7 @@ class Question < ApplicationRecord
   SHORT_QUESTION_MAX_LENGTH = 512
 
   before_destroy do
-    rep = Report.where(target_id: self.id, type: 'Reports::Question')
+    rep = Report.where(target_id: self.id, type: "Reports::Question")
     rep.each do |r|
       unless r.nil?
         r.deleted = true
@@ -25,8 +27,9 @@ class Question < ApplicationRecord
   end
 
   def can_be_removed?
-    return false if self.answers.count > 0
+    return false if self.answers.count.positive?
     return false if InboxEntry.where(question: self).count > 1
+
     true
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,7 +4,7 @@ class Question < ApplicationRecord
   belongs_to :user, optional: true
   has_many :anonymous_blocks, dependent: :nullify
   has_many :answers, dependent: :destroy
-  has_many :inboxes, dependent: :destroy
+  has_many :inbox_entries, dependent: :destroy
 
   validates :content, length: { minimum: 1 }
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -26,7 +26,7 @@ class Question < ApplicationRecord
 
   def can_be_removed?
     return false if self.answers.count > 0
-    return false if Inbox.where(question: self).count > 1
+    return false if InboxEntry.where(question: self).count > 1
     true
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
   has_many :questions, dependent: :destroy_async
   has_many :answers, dependent: :destroy_async
   has_many :comments, dependent: :destroy_async
-  has_many :inboxes, dependent: :destroy_async
+  has_many :inbox_entries, dependent: :destroy_async
   has_many :smiles, class_name: "Reaction", dependent: :destroy_async
   has_many :notifications, foreign_key: :recipient_id, dependent: :destroy_async
   has_many :reports, dependent: :destroy_async

--- a/app/models/user/inbox_methods.rb
+++ b/app/models/user/inbox_methods.rb
@@ -15,7 +15,7 @@ module User::InboxMethods
 
   def unread_inbox_count
     Rails.cache.fetch(inbox_cache_key, expires_in: 12.hours) do
-      count = Inbox.where(new: true, user_id: id).count(:id)
+      count = InboxEntry.where(new: true, user_id: id).count(:id)
 
       # Returning +nil+ here in order to not display a counter
       # at all when there isn't anything in the user's inbox

--- a/app/models/user/inbox_methods.rb
+++ b/app/models/user/inbox_methods.rb
@@ -5,9 +5,9 @@ module User::InboxMethods
 
   define_cursor_paginator :cursored_inbox, :ordered_inbox
 
-  # @return [ActiveRecord::Relation<Inbox>] the user's inbox entries
+  # @return [ActiveRecord::Relation<InboxEntry>] the user's inbox entries
   def ordered_inbox
-    inboxes
+    inbox_entries
       .includes(:question, user: :profile)
       .order(:created_at)
       .reverse_order

--- a/app/models/user/relationship/block.rb
+++ b/app/models/user/relationship/block.rb
@@ -53,8 +53,8 @@ class User
       def unfollow_and_remove(target_user)
         unfollow(target_user) if following?(target_user)
         target_user.unfollow(self) if target_user.following?(self)
-        target_user.inboxes.joins(:question).where(question: { user_id: id }).destroy_all
-        inboxes.joins(:question).where(questions: { user_id: target_user.id, author_is_anonymous: false }).destroy_all
+        target_user.inbox_entries.joins(:question).where(question: { user_id: id }).destroy_all
+        inbox_entries.joins(:question).where(questions: { user_id: target_user.id, author_is_anonymous: false }).destroy_all
         ListMember.joins(:list).where(list: { user_id: target_user.id }, user_id: id).destroy_all
       end
 

--- a/app/workers/question_worker.rb
+++ b/app/workers/question_worker.rb
@@ -16,7 +16,7 @@ class QuestionWorker
     user.followers.each do |f|
       next if skip_inbox?(f, question, user)
 
-      inbox = Inbox.create(user_id: f.id, question_id:, new: true)
+      inbox = InboxEntry.create(user_id: f.id, question_id:, new: true)
       f.push_notification(webpush_app, inbox) if webpush_app
     end
   rescue StandardError => e

--- a/app/workers/scheduler/inbox_cleanup_scheduler.rb
+++ b/app/workers/scheduler/inbox_cleanup_scheduler.rb
@@ -6,7 +6,7 @@ class Scheduler::InboxCleanupScheduler
   sidekiq_options retry: false
 
   def perform
-    orphaned_entries = Inbox.where(question_id: nil).includes(:user)
+    orphaned_entries = InboxEntry.where(question_id: nil).includes(:user)
     orphaned_entries.each do |inbox|
       logger.info "Deleting orphaned inbox entry #{inbox.id} from user #{inbox.user.id}"
       inbox.destroy

--- a/app/workers/send_to_inbox_job.rb
+++ b/app/workers/send_to_inbox_job.rb
@@ -14,7 +14,7 @@ class SendToInboxJob
 
     return if skip_inbox?(follower, question)
 
-    inbox = Inbox.create(user_id: follower.id, question_id:, new: true)
+    inbox = InboxEntry.create(user_id: follower.id, question_id:, new: true)
     follower.push_notification(webpush_app, inbox) if webpush_app
   end
 

--- a/db/migrate/20240127112216_rename_inboxes_to_inbox_entries.rb
+++ b/db/migrate/20240127112216_rename_inboxes_to_inbox_entries.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameInboxesToInboxEntries < ActiveRecord::Migration[7.0]
   def change
     rename_table :inboxes, :inbox_entries

--- a/db/migrate/20240127112216_rename_inboxes_to_inbox_entries.rb
+++ b/db/migrate/20240127112216_rename_inboxes_to_inbox_entries.rb
@@ -1,0 +1,5 @@
+class RenameInboxesToInboxEntries < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :inboxes, :inbox_entries
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_01_23_182422) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_27_112216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,13 +68,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_23_182422) do
   end
 
   create_table "inboxes", id: :serial, force: :cascade do |t|
+  create_table "inbox_entries", id: :serial, force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "question_id"
     t.boolean "new"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.index ["question_id"], name: "index_inboxes_on_question_id"
-    t.index ["user_id"], name: "index_inboxes_on_user_id"
+    t.index ["question_id"], name: "index_inbox_entries_on_question_id"
+    t.index ["user_id"], name: "index_inbox_entries_on_user_id"
   end
 
   create_table "list_members", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_23_182422) do
 ActiveRecord::Schema[7.0].define(version: 2024_01_27_112216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +66,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_27_112216) do
     t.index ["user_id", "created_at"], name: "index_comments_on_user_id_and_created_at"
   end
 
-  create_table "inboxes", id: :serial, force: :cascade do |t|
   create_table "inbox_entries", id: :serial, force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "question_id"

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -20,7 +20,7 @@ module UseCase
         increment_asked_count
         increment_metric
 
-        inbox = ::Inbox.create!(user: target_user, question:, new: true)
+        inbox = ::InboxEntry.create!(user: target_user, question:, new: true)
         notify(inbox)
 
         {

--- a/spec/controllers/ajax/answer_controller_spec.rb
+++ b/spec/controllers/ajax/answer_controller_spec.rb
@@ -65,7 +65,7 @@ describe Ajax::AnswerController, :ajax_controller, type: :controller do
         let(:shared_services) { %w[twitter] }
 
         context "when inbox is true" do
-          let(:id) { FactoryBot.create(:inbox, user: inbox_user, question:).id }
+          let(:id) { FactoryBot.create(:inbox_entry, user: inbox_user, question:).id }
           let(:inbox) { true }
 
           context "when the inbox entry belongs to the user" do
@@ -325,13 +325,13 @@ describe Ajax::AnswerController, :ajax_controller, type: :controller do
         include_examples "deletes the answer"
 
         it "returns the question back to the user's inbox" do
-          expect { subject }.to(change { Inbox.where(question_id: answer.question.id, user_id: user.id).count }.by(1))
+          expect { subject }.to(change { InboxEntry.where(question_id: answer.question.id, user_id: user.id).count }.by(1))
         end
 
         it "returns the question back to the user's inbox when the user has anonymous questions disabled" do
           user.privacy_allow_anonymous_questions = false
           user.save
-          expect { subject }.to(change { Inbox.where(question_id: answer.question.id, user_id: user.id).count }.by(1))
+          expect { subject }.to(change { InboxEntry.where(question_id: answer.question.id, user_id: user.id).count }.by(1))
         end
 
         it "updates the inbox caching timestamp for the user who answered" do

--- a/spec/controllers/ajax/inbox_controller_spec.rb
+++ b/spec/controllers/ajax/inbox_controller_spec.rb
@@ -7,11 +7,11 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
   describe "#remove" do
     let(:params) do
       {
-        id: inbox_entry_id
+        id: inbox_entry_id,
       }
     end
 
-    subject { delete(:remove, params: params) }
+    subject { delete(:remove, params:) }
 
     context "when user is signed in" do
       before(:each) { sign_in(user) }
@@ -28,8 +28,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
           let(:expected_response) do
             {
               "success" => true,
-              "status" => "okay",
-              "message" => anything
+              "status"  => "okay",
+              "message" => anything,
             }
           end
 
@@ -46,8 +46,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
           let(:expected_response) do
             {
               "success" => false,
-              "status" => "fail",
-              "message" => anything
+              "status"  => "fail",
+              "message" => anything,
             }
           end
 
@@ -65,8 +65,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
         let(:expected_response) do
           {
             "success" => false,
-            "status" => "not_found",
-            "message" => anything
+            "status"  => "not_found",
+            "message" => anything,
           }
         end
 
@@ -79,8 +79,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       let(:expected_response) do
         {
           "success" => false,
-          "status" => "not_found",
-          "message" => anything
+          "status"  => "not_found",
+          "message" => anything,
         }
       end
 
@@ -97,8 +97,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       let(:expected_response) do
         {
           "success" => true,
-          "status" => "okay",
-          "message" => anything
+          "status"  => "okay",
+          "message" => anything,
         }
       end
 
@@ -107,7 +107,7 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       context "when user has some inbox entries" do
         let(:some_other_user) { FactoryBot.create(:user) }
         before do
-          10.times { FactoryBot.create(:inbox_entry, user: user) }
+          10.times { FactoryBot.create(:inbox_entry, user:) }
           10.times { FactoryBot.create(:inbox_entry, user: some_other_user) }
         end
 
@@ -123,8 +123,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       let(:expected_response) do
         {
           "success" => false,
-          "status" => "err",
-          "message" => anything
+          "status"  => "err",
+          "message" => anything,
         }
       end
 
@@ -135,11 +135,11 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
   describe "#remove_all_author" do
     let(:params) do
       {
-        author: author
+        author:,
       }
     end
 
-    subject { delete(:remove_all_author, params: params) }
+    subject { delete(:remove_all_author, params:) }
 
     context "when user is signed in" do
       before(:each) { sign_in(user) }
@@ -148,8 +148,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       let(:expected_response) do
         {
           "success" => true,
-          "status" => "okay",
-          "message" => anything
+          "status"  => "okay",
+          "message" => anything,
         }
       end
 
@@ -162,9 +162,9 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
           normal_question = FactoryBot.create(:question, user: some_other_user, author_is_anonymous: false)
           anon_question = FactoryBot.create(:question, user: some_other_user, author_is_anonymous: true)
 
-          10.times { FactoryBot.create(:inbox_entry, user: user) }
-          3.times { FactoryBot.create(:inbox_entry, user: user, question: normal_question) }
-          2.times { FactoryBot.create(:inbox_entry, user: user, question: anon_question) }
+          10.times { FactoryBot.create(:inbox_entry, user:) }
+          3.times { FactoryBot.create(:inbox_entry, user:, question: normal_question) }
+          2.times { FactoryBot.create(:inbox_entry, user:, question: anon_question) }
         end
 
         it "deletes all the entries asked by some other user which are not anonymous from the user's inbox" do
@@ -179,8 +179,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
         let(:expected_response) do
           {
             "success" => false,
-            "status" => "err",
-            "message" => anything
+            "status"  => "err",
+            "message" => anything,
           }
         end
 
@@ -193,8 +193,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       let(:expected_response) do
         {
           "success" => false,
-          "status" => "err",
-          "message" => anything
+          "status"  => "err",
+          "message" => anything,
         }
       end
 

--- a/spec/controllers/ajax/inbox_controller_spec.rb
+++ b/spec/controllers/ajax/inbox_controller_spec.rb
@@ -17,7 +17,7 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       before(:each) { sign_in(user) }
 
       context "when inbox entry exists" do
-        let(:inbox_entry) { FactoryBot.create(:inbox, user: inbox_user) }
+        let(:inbox_entry) { FactoryBot.create(:inbox_entry, user: inbox_user) }
         let(:inbox_entry_id) { inbox_entry.id }
 
         # ensure the inbox entry exists
@@ -35,7 +35,7 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
 
           it "removes the inbox entry" do
             expect { subject }.to(change { user.inboxes.count }.by(-1))
-            expect { Inbox.find(inbox_entry.id) }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { InboxEntry.find(inbox_entry.id) }.to raise_error(ActiveRecord::RecordNotFound)
           end
 
           include_examples "returns the expected response"
@@ -112,7 +112,7 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
         end
 
         it "deletes all the entries from the user's inbox" do
-          expect { subject }.to(change { [Inbox.count, user.inboxes.count] }.from([20, 10]).to([10, 0]))
+          expect { subject }.to(change { [InboxEntry.count, user.inbox_entries.count] }.from([20, 10]).to([10, 0]))
         end
 
         include_examples "returns the expected response"

--- a/spec/controllers/ajax/inbox_controller_spec.rb
+++ b/spec/controllers/ajax/inbox_controller_spec.rb
@@ -34,7 +34,7 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
           end
 
           it "removes the inbox entry" do
-            expect { subject }.to(change { user.inboxes.count }.by(-1))
+            expect { subject }.to(change { user.inbox_entries.count }.by(-1))
             expect { InboxEntry.find(inbox_entry.id) }.to raise_error(ActiveRecord::RecordNotFound)
           end
 
@@ -52,8 +52,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
           end
 
           it "does not remove the inbox entry" do
-            expect { subject }.not_to(change { Inbox.count })
-            expect { Inbox.find(inbox_entry.id) }.not_to raise_error
+            expect { subject }.not_to(change { InboxEntry.count })
+            expect { InboxEntry.find(inbox_entry.id) }.not_to raise_error
           end
 
           include_examples "returns the expected response"
@@ -107,8 +107,8 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
       context "when user has some inbox entries" do
         let(:some_other_user) { FactoryBot.create(:user) }
         before do
-          10.times { FactoryBot.create(:inbox, user: user) }
-          10.times { FactoryBot.create(:inbox, user: some_other_user) }
+          10.times { FactoryBot.create(:inbox_entry, user: user) }
+          10.times { FactoryBot.create(:inbox_entry, user: some_other_user) }
         end
 
         it "deletes all the entries from the user's inbox" do
@@ -162,13 +162,13 @@ describe Ajax::InboxController, :ajax_controller, type: :controller do
           normal_question = FactoryBot.create(:question, user: some_other_user, author_is_anonymous: false)
           anon_question = FactoryBot.create(:question, user: some_other_user, author_is_anonymous: true)
 
-          10.times { FactoryBot.create(:inbox, user: user) }
-          3.times { FactoryBot.create(:inbox, user: user, question: normal_question) }
-          2.times { FactoryBot.create(:inbox, user: user, question: anon_question) }
+          10.times { FactoryBot.create(:inbox_entry, user: user) }
+          3.times { FactoryBot.create(:inbox_entry, user: user, question: normal_question) }
+          2.times { FactoryBot.create(:inbox_entry, user: user, question: anon_question) }
         end
 
         it "deletes all the entries asked by some other user which are not anonymous from the user's inbox" do
-          expect { subject }.to(change { user.inboxes.count }.from(15).to(12))
+          expect { subject }.to(change { user.inbox_entries.count }.from(15).to(12))
         end
 
         include_examples "returns the expected response"

--- a/spec/controllers/ajax/question_controller_spec.rb
+++ b/spec/controllers/ajax/question_controller_spec.rb
@@ -14,8 +14,8 @@ describe Ajax::QuestionController, :ajax_controller, type: :controller do
 
       if check_for_inbox
         it "adds the question to the target users' inbox" do
-          expect { subject }.to(change { target_user.inboxes.count }.by(1))
-          expect(target_user.inboxes.last.question.content).to eq(question_content)
+          expect { subject }.to(change { target_user.inbox_entries.count }.by(1))
+          expect(target_user.inbox_entries.last.question.content).to eq(question_content)
         end
       end
 
@@ -29,7 +29,7 @@ describe Ajax::QuestionController, :ajax_controller, type: :controller do
 
       if check_for_inbox
         it "does not add the question to the target users' inbox" do
-          expect { subject }.not_to(change { target_user.inboxes.count })
+          expect { subject }.not_to(change { target_user.inbox_entries.count })
         end
       end
 
@@ -42,7 +42,7 @@ describe Ajax::QuestionController, :ajax_controller, type: :controller do
       end
 
       it "does not add the question to the target users' inbox" do
-        expect { subject }.not_to(change { target_user.inboxes.count })
+        expect { subject }.not_to(change { target_user.inbox_entries.count })
       end
 
       include_examples "returns the expected response"

--- a/spec/controllers/anonymous_block_controller_spec.rb
+++ b/spec/controllers/anonymous_block_controller_spec.rb
@@ -15,7 +15,7 @@ describe AnonymousBlockController, type: :controller do
 
       context "when all required parameters are given" do
         let(:question) { FactoryBot.create(:question, author_identifier: "someidentifier") }
-        let!(:inbox) { FactoryBot.create(:inbox, user:, question:) }
+        let!(:inbox) { FactoryBot.create(:inbox_entry, user:, question:) }
         let(:params) do
           { question: question.id }
         end
@@ -50,7 +50,7 @@ describe AnonymousBlockController, type: :controller do
 
       context "when blocking a user globally" do
         let(:question) { FactoryBot.create(:question, author_identifier: "someidentifier") }
-        let!(:inbox) { FactoryBot.create(:inbox, user:, question:) }
+        let!(:inbox) { FactoryBot.create(:inbox_entry, user:, question:) }
         let(:params) do
           { question: question.id, global: "true" }
         end

--- a/spec/controllers/inbox_controller_spec.rb
+++ b/spec/controllers/inbox_controller_spec.rb
@@ -131,7 +131,7 @@ describe InboxController, type: :controller do
         let!(:unrelated_user) { FactoryBot.create(:user) }
 
         let!(:generic_inbox_entry1) do
-          Inbox.create(
+          InboxEntry.create(
             user:,
             question: FactoryBot.create(
               :question,
@@ -140,7 +140,7 @@ describe InboxController, type: :controller do
             ),
           )
         end
-        let!(:generic_inbox_entry2) { Inbox.create(user:, question: FactoryBot.create(:question)) }
+        let!(:generic_inbox_entry2) { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
 
         subject { get :show, params: { author: author_param } }
 
@@ -163,7 +163,7 @@ describe InboxController, type: :controller do
 
           context "with no non-anonymous questions from the other user in the inbox" do
             let!(:anonymous_inbox_entry) do
-              Inbox.create(
+              InboxEntry.create(
                 user:,
                 question: FactoryBot.create(
                   :question,
@@ -188,7 +188,7 @@ describe InboxController, type: :controller do
 
           context "with both non-anonymous and anonymous questions from the other user in the inbox" do
             let!(:non_anonymous_inbox_entry) do
-              Inbox.create(
+              InboxEntry.create(
                 user:,
                 question: FactoryBot.create(
                   :question,
@@ -198,7 +198,7 @@ describe InboxController, type: :controller do
               )
             end
             let!(:anonymous_inbox_entry) do
-              Inbox.create(
+              InboxEntry.create(
                 user:,
                 question: FactoryBot.create(
                   :question,
@@ -227,7 +227,7 @@ describe InboxController, type: :controller do
       context "when passed the anonymous param" do
         let!(:other_user) { FactoryBot.create(:user) }
         let!(:generic_inbox_entry) do
-          Inbox.create(
+          InboxEntry.create(
             user:,
             question: FactoryBot.create(
               :question,
@@ -239,7 +239,7 @@ describe InboxController, type: :controller do
 
         let!(:inbox_entry_fillers) do
           # 9 times => 1 entry less than default page size
-          9.times.map { Inbox.create(user:, question: FactoryBot.create(:question, author_is_anonymous: true)) }
+          9.times.map { InboxEntry.create(user:, question: FactoryBot.create(:question, author_is_anonymous: true)) }
         end
 
         subject { get :show, params: { anonymous: true } }
@@ -258,7 +258,7 @@ describe InboxController, type: :controller do
       context "when passed the anonymous and the author param" do
         let!(:other_user) { FactoryBot.create(:user) }
         let!(:generic_inbox_entry) do
-          Inbox.create(
+          InboxEntry.create(
             user:,
             question: FactoryBot.create(
               :question,
@@ -270,7 +270,7 @@ describe InboxController, type: :controller do
 
         let!(:inbox_entry_fillers) do
           # 9 times => 1 entry less than default page size
-          9.times.map { Inbox.create(user:, question: FactoryBot.create(:question, author_is_anonymous: true)) }
+          9.times.map { InboxEntry.create(user:, question: FactoryBot.create(:question, author_is_anonymous: true)) }
         end
 
         subject { get :show, params: { anonymous: true, author: "some_name" } }
@@ -299,7 +299,7 @@ describe InboxController, type: :controller do
       before(:each) { sign_in(user) }
 
       it "creates an inbox entry" do
-        expect { subject }.to(change { user.inboxes.count }.by(1))
+        expect { subject }.to(change { user.inbox_entries.count }.by(1))
       end
 
       include_examples "touches user timestamp", :inbox_updated_at

--- a/spec/controllers/inbox_controller_spec.rb
+++ b/spec/controllers/inbox_controller_spec.rb
@@ -46,7 +46,7 @@ describe InboxController, type: :controller do
       end
 
       context "when inbox has an amount of questions less than page size" do
-        let!(:inbox_entry) { Inbox.create(user:, new: true, question: FactoryBot.create(:question)) }
+        let!(:inbox_entry) { InboxEntry.create(user:, new: true, question: FactoryBot.create(:question)) }
 
         include_examples "sets the expected ivars" do
           let(:expected_assigns) do
@@ -79,13 +79,13 @@ describe InboxController, type: :controller do
       context "when inbox has an amount of questions more than page size" do
         let(:inbox_entry_fillers_page1) do
           # 9 times => 1 entry less than default page size
-          9.times.map { Inbox.create(user:, question: FactoryBot.create(:question)) }
+          9.times.map { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
         end
-        let(:last_inbox_entry_page1) { Inbox.create(user:, question: FactoryBot.create(:question)) }
+        let(:last_inbox_entry_page1) { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
         let(:inbox_entry_fillers_page2) do
-          5.times.map { Inbox.create(user:, question: FactoryBot.create(:question)) }
+          5.times.map { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
         end
-        let(:last_inbox_entry_page2) { Inbox.create(user:, question: FactoryBot.create(:question)) }
+        let(:last_inbox_entry_page2) { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
 
         before do
           # create inbox entries in reverse so pagination works as expected

--- a/spec/controllers/moderation/inbox_controller_spec.rb
+++ b/spec/controllers/moderation/inbox_controller_spec.rb
@@ -7,7 +7,7 @@ describe Moderation::InboxController do
     subject { get :index, params: params }
 
     let(:target_user) { FactoryBot.create(:user) }
-    let!(:inboxes) { FactoryBot.create_list(:inbox, 60, user: target_user) }
+    let!(:inboxes) { FactoryBot.create_list(:inbox_entry, 60, user: target_user) }
     let(:params) { { user: target_user.screen_name } }
 
     context "moderator signed in" do

--- a/spec/factories/inbox_entry.rb
+++ b/spec/factories/inbox_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :inbox do
+  factory :inbox_entry do
     question { FactoryBot.build(:question) }
     new { true }
   end

--- a/spec/lib/use_case/question/create_spec.rb
+++ b/spec/lib/use_case/question/create_spec.rb
@@ -23,9 +23,9 @@ describe UseCase::Question::Create do
       expect(question.direct).to eq(true)
 
       if should_send_to_inbox
-        expect(target_user.inboxes.first.question_id).to eq(question.id)
+        expect(target_user.inbox_entries.first.question_id).to eq(question.id)
       else
-        expect(target_user.inboxes.first).to be_nil
+        expect(target_user.inbox_entries.first).to be_nil
       end
     end
   end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -27,7 +27,7 @@ describe Answer, type: :model do
       end
 
       it "should remove the question from the user's inbox" do
-        expect { subject.save }.to change { user.inboxes.count }.by(-1)
+        expect { subject.save }.to change { user.inbox_entries.count }.by(-1)
       end
     end
 

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -23,7 +23,7 @@ describe Answer, type: :model do
 
     context "user has the question in their inbox" do
       before do
-        Inbox.create(user:, question:, new: true)
+        InboxEntry.create(user:, question:, new: true)
       end
 
       it "should remove the question from the user's inbox" do

--- a/spec/models/inbox_entry_spec.rb
+++ b/spec/models/inbox_entry_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Inbox, type: :model do
+describe InboxEntry, type: :model do
   describe "associations" do
     it { should belong_to(:user) }
     it { should belong_to(:question) }
@@ -13,7 +13,7 @@ describe Inbox, type: :model do
     let(:question) { FactoryBot.create(:question, author_is_anonymous: true) }
 
     it "does not fail if the user wants to delete their account" do
-      Inbox.create(user:, question:)
+      InboxEntry.create(user:, question:)
 
       # this deletes the User record and enqueues the deletion of all
       # associated records in sidekiq

--- a/spec/models/user/inbox_methods_spec.rb
+++ b/spec/models/user/inbox_methods_spec.rb
@@ -18,7 +18,7 @@ describe User::InboxMethods do
       context "user has 1 question in their inbox" do
         # FactoryBot seems to have issues with setting the +new+ field on inbox entries
         # so we can create it manually instead
-        let!(:inbox) { Inbox.create(question: FactoryBot.create(:question), user:, new: true) }
+        let!(:inbox) { InboxEntry.create(question: FactoryBot.create(:question), user:, new: true) }
 
         it "should return 1" do
           expect(subject).to eq(1)

--- a/spec/views/inbox/_entry.html.haml_spec.rb
+++ b/spec/views/inbox/_entry.html.haml_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "inbox/_entry.html.haml", type: :view do
-  let(:inbox_entry)         { Inbox.create(user: inbox_user, question:, new:) }
+  let(:inbox_entry)         { InboxEntry.create(user: inbox_user, question:, new:) }
   let(:inbox_user)          { user }
   let(:user)                { FactoryBot.create(:user, sharing_enabled:, sharing_custom_url:) }
   let(:sharing_enabled)     { true }

--- a/spec/views/inbox/show.html.haml_spec.rb
+++ b/spec/views/inbox/show.html.haml_spec.rb
@@ -25,8 +25,8 @@ describe "inbox/show.html.haml", type: :view do
   end
 
   context "with some inbox entries" do
-    let(:inbox_entry1) { Inbox.create(user:, question: FactoryBot.create(:question)) }
-    let(:inbox_entry2) { Inbox.create(user:, question: FactoryBot.create(:question)) }
+    let(:inbox_entry1) { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
+    let(:inbox_entry2) { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
 
     before do
       assign :inbox, [inbox_entry2, inbox_entry1]

--- a/spec/views/inbox/show.turbo_stream.haml_spec.rb
+++ b/spec/views/inbox/show.turbo_stream.haml_spec.rb
@@ -12,8 +12,8 @@ describe "inbox/show.turbo_stream.haml", type: :view do
   subject(:rendered) { render }
 
   context "with some inbox entries" do
-    let(:inbox_entry1) { Inbox.create(user:, question: FactoryBot.create(:question)) }
-    let(:inbox_entry2) { Inbox.create(user:, question: FactoryBot.create(:question)) }
+    let(:inbox_entry1) { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
+    let(:inbox_entry2) { InboxEntry.create(user:, question: FactoryBot.create(:question)) }
 
     before do
       assign :inbox, [inbox_entry2, inbox_entry1]

--- a/spec/workers/question_worker_spec.rb
+++ b/spec/workers/question_worker_spec.rb
@@ -22,7 +22,7 @@ describe QuestionWorker do
     it "places the question in the inbox of the user's followers" do
       expect { subject }
         .to(
-          change { Inbox.where(user_id: user.followers.ids, question_id:, new: true).count }
+          change { InboxEntry.where(user_id: user.followers.ids, question_id:, new: true).count }
             .from(0)
             .to(5)
         )
@@ -36,7 +36,7 @@ describe QuestionWorker do
 
       expect { subject }
         .to(
-          change { Inbox.where(user_id: user.followers.ids, question_id:, new: true).count }
+          change { InboxEntry.where(user_id: user.followers.ids, question_id:, new: true).count }
             .from(0)
             .to(4)
         )
@@ -47,7 +47,7 @@ describe QuestionWorker do
 
       expect { subject }
         .to(
-          change { Inbox.where(user_id: user.followers.ids, question_id:, new: true).count }
+          change { InboxEntry.where(user_id: user.followers.ids, question_id:, new: true).count }
             .from(0)
             .to(4)
         )
@@ -58,7 +58,7 @@ describe QuestionWorker do
 
       expect { subject }
         .to(
-          change { Inbox.where(user_id: user.followers.ids, question_id:, new: true).count }
+          change { InboxEntry.where(user_id: user.followers.ids, question_id:, new: true).count }
             .from(0)
             .to(4)
         )
@@ -102,7 +102,7 @@ describe QuestionWorker do
 
         expect { subject }
           .to(
-            change { Inbox.where(user_id: user.followers.ids, question_id:, new: true).count }
+            change { InboxEntry.where(user_id: user.followers.ids, question_id:, new: true).count }
               .from(0)
               .to(1)
           )

--- a/spec/workers/scheduler/inbox_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/inbox_cleanup_scheduler_spec.rb
@@ -17,7 +17,7 @@ describe Scheduler::InboxCleanupScheduler do
     it "should delete orphaned inbox entries" do
       expect { subject }
         .to(
-          change { Inbox.where(question_id: nil).count }
+          change { InboxEntry.where(question_id: nil).count }
             .from(1)
             .to(0),
         )

--- a/spec/workers/scheduler/inbox_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/inbox_cleanup_scheduler_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe Scheduler::InboxCleanupScheduler do
   let(:user) { FactoryBot.create(:user) }
-  let(:inbox) { FactoryBot.create(:inbox, user:) }
+  let(:inbox) { FactoryBot.create(:inbox_entry, user:) }
 
   describe "#perform" do
     before do

--- a/spec/workers/send_to_inbox_job_spec.rb
+++ b/spec/workers/send_to_inbox_job_spec.rb
@@ -21,7 +21,7 @@ describe SendToInboxJob do
     it "places the question in the inbox of the user's followers" do
       expect { subject }
         .to(
-          change { Inbox.where(user_id: follower_id, question_id:, new: true).count }
+          change { InboxEntry.where(user_id: follower_id, question_id:, new: true).count }
             .from(0)
             .to(1),
         )
@@ -34,21 +34,21 @@ describe SendToInboxJob do
       MuteRule.create(user_id: follower_id, muted_phrase: "spicy")
 
       subject
-      expect(Inbox.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
+      expect(InboxEntry.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
     end
 
     it "respects inbox locks" do
       follower.update(privacy_lock_inbox: true)
 
       subject
-      expect(Inbox.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
+      expect(InboxEntry.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
     end
 
     it "does not send questions to banned users" do
       follower.ban
 
       subject
-      expect(Inbox.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
+      expect(InboxEntry.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
     end
 
     context "receiver has push notifications enabled" do
@@ -86,7 +86,7 @@ describe SendToInboxJob do
 
         expect { subject }
           .to(
-            change { Inbox.where(user_id: follower_id, question_id:, new: true).count }
+            change { InboxEntry.where(user_id: follower_id, question_id:, new: true).count }
               .from(0)
               .to(1),
           )
@@ -94,7 +94,7 @@ describe SendToInboxJob do
 
       it "does not send to recipients who do not allow long questions" do
         subject
-        expect(Inbox.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
+        expect(InboxEntry.where(user_id: follower_id, question_id:, new: true).count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Fixes #1564

Makes a lot more sense in terms of naming, since users don't have many inboxes, they have many inbox entries.

