### PR TITLE
Implement report filtering UI

### DIFF
--- a/app/controllers/moderation/reports_controller.rb
+++ b/app/controllers/moderation/reports_controller.rb
@@ -2,6 +2,8 @@
 
 class Moderation::ReportsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_filter_enabled
+  before_action :set_type_options
 
   def index
     filter = ReportFilter.new(filter_params)
@@ -19,5 +21,22 @@ class Moderation::ReportsController < ApplicationController
 
   def filter_params
     params.slice(*ReportFilter::KEYS).permit(*ReportFilter::KEYS)
+  end
+
+  def set_filter_enabled
+    @filter_enabled = params.slice(*ReportFilter::KEYS)
+                            .reject! { |_, value| value.empty? || value.nil? }
+                            .values
+                            .any?
+  end
+
+  def set_type_options
+    @type_options = [
+      [t("voc.all"), ""],
+      [t("activerecord.models.answer.one"), :answer],
+      [t("activerecord.models.comment.one"), :comment],
+      [t("activerecord.models.question.one"), :question],
+      [t("activerecord.models.user.one"), :user]
+    ]
   end
 end

--- a/app/views/moderation/reports/index.html.haml
+++ b/app/views/moderation/reports/index.html.haml
@@ -1,3 +1,17 @@
+.card
+  .card-body
+    .dropdown
+      %button.btn.dropdown-toggle{ class: @filter_enabled ? "btn-primary" : "btn-light", type: :button, data: { bs_toggle: :dropdown }, aria: { expanded: :false }}
+        %i.fa.fa-filter
+        = t("voc.filter")
+      .dropdown-menu{ style: "min-width: 300px;" }
+        = bootstrap_form_tag url: moderation_reports_path, method: :get, html: { class: "px-3 py-2" } do |f|
+          = f.select :type, options_for_select(@type_options, params[:type]), {}, { class: "form-control" }
+          = f.text_field :user, value: params[:user]
+          = f.text_field :target_user, value: params[:target_user]
+          .d-flex.flex-row-reverse
+            = f.primary t("voc.filter")
+
 #reports
   - if @reports.empty?
     = render "shared/empty", icon: "fa-regular fa-smile-beam", translation_key: ".moderation.reports"

--- a/app/views/moderation/reports/index.html.haml
+++ b/app/views/moderation/reports/index.html.haml
@@ -1,7 +1,10 @@
 .card
   .card-body
     .dropdown
-      %button.btn.dropdown-toggle{ class: @filter_enabled ? "btn-primary" : "btn-light", type: :button, data: { bs_toggle: :dropdown }, aria: { expanded: :false }}
+      %button.btn.dropdown-toggle{ class: @filter_enabled ? "btn-primary" : "btn-light",
+                                   type: :button,
+                                   data: { bs_toggle: :dropdown },
+                                   aria: { expanded: :false } }
         %i.fa.fa-filter
         = t("voc.filter")
       .dropdown-menu{ style: "min-width: 300px;" }

--- a/app/views/tabs/_moderation.html.haml
+++ b/app/views/tabs/_moderation.html.haml
@@ -1,13 +1,6 @@
 .card
   .list-group
-    = list_group_item t(".all"), moderation_reports_path
-    = list_group_item t(".answers"), moderation_reports_path("answer")
-    = list_group_item t(".comments"), moderation_reports_path("comment")
-    = list_group_item t(".users"), moderation_reports_path("user")
-    = list_group_item t(".questions"), moderation_reports_path("question")
-
-.card
-  .list-group
+    = list_group_item t(".reports"), moderation_reports_path
     = list_group_item t(".site_wide_blocks"), mod_anon_block_index_path
 
 .d-none.d-sm-block= render "shared/links"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -644,11 +644,7 @@ en:
           title: "Members"
           none: "No members yet."
     moderation:
-      all: "All reports"
-      answers: :activerecord.models.answer.other
-      comments: :activerecord.models.comment.other
-      users: :activerecord.models.user.other
-      questions: :activerecord.models.question.other
+      reports: "Reports"
       site_wide_blocks: "Site-wide anonymous blocks"
     notifications:
       all: "All notifications"

--- a/config/locales/voc.en.yml
+++ b/config/locales/voc.en.yml
@@ -1,6 +1,7 @@
 en:
   voc:
     add: "Add"
+    all: "All"
     answer: "Answer"
     block: "Block"
     block_site_wide: "Block user site-wide"
@@ -9,6 +10,7 @@ en:
     confirm: "Are you sure?"
     delete: "Delete"
     edit: "Edit"
+    filter: "Filter"
     follow: "Follow"
     format_markdown: "Styling with Markdown is supported"
     load: "Load more"


### PR DESCRIPTION
Goes in line with adding all the new filtering options for reports.

Filter opened as a dropdown:
![image](https://github.com/Retrospring/retrospring/assets/1774242/94d5e560-d9e7-452a-bc14-ffc99c675c19)

If anything else than the default values (so, nothing) is set, the button is highlighted:
![image](https://github.com/Retrospring/retrospring/assets/1774242/dcb3e3bc-2362-46f5-a97b-c500f725ad7a)
