### PR TITLE
Add links to user actions to filter reports by/from users

### DIFF
--- a/app/views/user/_actions.html.haml
+++ b/app/views/user/_actions.html.haml
@@ -32,9 +32,15 @@
             %i.fa.fa-exclamation-triangle.fa-fw
             = t("voc.report")
           - if current_user.mod?
+            %a.dropdown-item{ href: moderation_reports_path(user: user.screen_name) }
+              %i.far.fa-flag.fa-fw
+              = t(".reports_from", user: user.screen_name)
+            %a.dropdown-item{ href: moderation_reports_path(target_user: user.screen_name) }
+              %i.fas.fa-flag.fa-fw
+              = t(".reports_of", user: user.screen_name)
             %a.dropdown-item{ href: '#', data: { bs_target: '#modal-privileges', bs_toggle: :modal } }
               %i.fa.fa-wrench.fa-fw
-              = raw t(".privilege", user: user.screen_name)
+              = t(".privilege", user: user.screen_name)
             - unless user.has_cached_role?(:administrator)
               %a.dropdown-item{ href: '#', data: { bs_target: '#modal-ban', bs_toggle: :modal } }
                 %i.fa.fa-ban.fa-fw

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -703,6 +703,8 @@ en:
       ban: "Ban Control"
       title: "Actions"
       list: "Manage list memberships"
+      reports_from: "Reports from %{user}"
+      reports_of: "Reports of %{user}"
     profile:
       badge:
         admin: "Admin"


### PR DESCRIPTION
Adds new links to user actions:
* Reports from user (filtering reports by `user` with the current user)
* Reports of user (filtering reports by `target_user` with the current user)

![image](https://github.com/Retrospring/retrospring/assets/1774242/ef56facd-76da-49d3-aa32-fe8fb984d383)

I know there's a lot of actions for users at the moment, I'll eventually reduce this with adding a moderation overview page for users.