### PR TITLE
Fix not being able to unset administrator privileges in UI

### DIFF
--- a/app/controllers/ajax/moderation_controller.rb
+++ b/app/controllers/ajax/moderation_controller.rb
@@ -84,7 +84,7 @@ class Ajax::ModerationController < AjaxController
     target_user = User.find_by_screen_name!(params[:user])
 
     @response[:message] = t(".error")
-    return unless %w(moderator admin).include? params[:type].downcase
+    return unless %w(moderator administrator).include? params[:type].downcase
 
     unless current_user.has_cached_role?(:administrator)
       @response[:status] = :nopriv
@@ -94,7 +94,7 @@ class Ajax::ModerationController < AjaxController
 
     @response[:checked] = status
     type = params[:type].downcase
-    target_role = {'admin' => 'administrator'}.fetch(type, type).to_sym
+    target_role = type.to_sym
 
     if status
       target_user.add_role target_role

--- a/app/controllers/ajax/moderation_controller.rb
+++ b/app/controllers/ajax/moderation_controller.rb
@@ -84,7 +84,7 @@ class Ajax::ModerationController < AjaxController
     target_user = User.find_by_screen_name!(params[:user])
 
     @response[:message] = t(".error")
-    return unless %w(moderator administrator).include? params[:type].downcase
+    return unless %w[moderator administrator].include? params[:type].downcase
 
     unless current_user.has_cached_role?(:administrator)
       @response[:status] = :nopriv

--- a/app/views/modal/_privileges.html.haml
+++ b/app/views/modal/_privileges.html.haml
@@ -9,6 +9,6 @@
       %ul.list-group
         - if current_user.has_cached_role?(:administrator)
           = render "modal/privileges/item", privilege: "moderator", description: t(".role.moderator"), user: user
-          = render "modal/privileges/item", privilege: "admin", description: t(".role.admin"), user: user
+          = render "modal/privileges/item", privilege: "administrator", description: t(".role.admin"), user: user
       .modal-footer
         %button.btn.btn-primary{ name: "checked-privileges", type: :button, data: { bs_dismiss: :modal } }= t("voc.close")

--- a/app/views/modal/privileges/_item.html.haml
+++ b/app/views/modal/privileges/_item.html.haml
@@ -3,7 +3,11 @@
 %li.list-group-item{ id: "privilege-#{privilege}" }
   .d-flex
     .flex-shrink-0
-      %input{ type: :checkbox, name: "check-your-privileges", data: { type: privilege, user: user.screen_name }, checked: user.has_cached_role?(privilege.to_sym), autocomplete: :off }
+      %input{ type: :checkbox,
+              name: "check-your-privileges",
+              data: { type: privilege, user: user.screen_name },
+              checked: user.has_cached_role?(privilege.to_sym),
+              autocomplete: :off }
     .flex-grow-1
       .list-group-item-heading= privilege.capitalize
       - unless description.blank?

--- a/app/views/modal/privileges/_item.html.haml
+++ b/app/views/modal/privileges/_item.html.haml
@@ -1,12 +1,9 @@
 :ruby
   description ||= ""
-  role_mapping = { admin: "administrator" }
-  requires_role = %w[admin moderator].include?(privilege)
-  checked = requires_role ? user.has_cached_role?(role_mapping.fetch(privilege, privilege).to_sym) : user.public_send("#{privilege}?")
 %li.list-group-item{ id: "privilege-#{privilege}" }
   .d-flex
     .flex-shrink-0
-      %input{ type: :checkbox, name: "check-your-privileges", data: { type: privilege, user: user.screen_name }, checked: checked, autocomplete: :off }
+      %input{ type: :checkbox, name: "check-your-privileges", data: { type: privilege, user: user.screen_name }, checked: user.has_cached_role?(privilege.to_sym), autocomplete: :off }
     .flex-grow-1
       .list-group-item-heading= privilege.capitalize
       - unless description.blank?

--- a/spec/controllers/ajax/moderation_controller_spec.rb
+++ b/spec/controllers/ajax/moderation_controller_spec.rb
@@ -225,7 +225,7 @@ describe Ajax::ModerationController, :ajax_controller, type: :controller do
   describe "#privilege" do
     valid_role_pairs = {
       moderator: :moderator,
-      admin: :administrator
+      administrator: :administrator
     }.freeze
 
     let(:params) do

--- a/spec/controllers/ajax/moderation_controller_spec.rb
+++ b/spec/controllers/ajax/moderation_controller_spec.rb
@@ -225,7 +225,7 @@ describe Ajax::ModerationController, :ajax_controller, type: :controller do
   describe "#privilege" do
     valid_role_pairs = {
       moderator: :moderator,
-      administrator: :administrator
+      administrator: :administrator,
     }.freeze
 
     let(:params) do


### PR DESCRIPTION
Simplifies the item partial and fixes the issue that the administrator role simply was unchecked for admins after setting it.