### PR TITLE
Fix text color of answerbox actions

### DIFF
--- a/app/assets/stylesheets/components/_answerbox.scss
+++ b/app/assets/stylesheets/components/_answerbox.scss
@@ -35,9 +35,9 @@
   }
 
   &__action {
-    padding-left: 0;
-    padding-right: map.get($spacers, 1);
     color: RGBA(var(--raised-text), 0.75);
+    padding: var(--btn-padding-y);
+    margin-right: map.get($spacers, 1);
     text-decoration: none;
 
     & i {
@@ -66,6 +66,10 @@
       &:hover {
         color: var(--danger);
       }
+    }
+
+    &.dropdown-toggle::after {
+      margin-left: 0;
     }
   }
 

--- a/app/assets/stylesheets/components/_answerbox.scss
+++ b/app/assets/stylesheets/components/_answerbox.scss
@@ -37,6 +37,7 @@
   &__action {
     padding-left: 0;
     padding-right: map.get($spacers, 1);
+    color: RGBA(var(--raised-text), 0.75);
     text-decoration: none;
 
     & i {
@@ -47,6 +48,7 @@
     &:hover,
     &:focus,
     &:active {
+      color: RGBA(var(--raised-text), 1);
       text-decoration: none;
     }
 

--- a/app/views/answerbox/_actions.html.haml
+++ b/app/views/answerbox/_actions.html.haml
@@ -6,12 +6,12 @@
   %button.btn.btn-link.answerbox__action{ type: :button, name: "ab-comments", data: { a_id: a.id, state: :hidden, selection_hotkey: "x" } }
     %i.fa.fa-fw.fa-comments
     %span{ id: "ab-comment-count-#{a.id}" }= a.comment_count
-.btn-group
+.dropdown.d-inline
   %button.btn.btn-link.answerbox__action{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
     %i.fa.fa-fw.fa-share-alt{ title: t(".share.title") }
   = render "actions/share", answer: a
 - if user_signed_in?
-  .btn-group
-    %button.btn.btn-default.btn-sm.dropdown-toggle{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
+  .dropdown.d-inline
+    %button.btn.btn-link.answerbox__action.dropdown-toggle{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
       %span.caret
     = render "actions/answer", answer: a

--- a/app/views/answerbox/_comments.html.haml
+++ b/app/views/answerbox/_comments.html.haml
@@ -20,7 +20,7 @@
               = render "reactions/destroy", type: "Comment", target: comment
             - else
               = render "reactions/create", type: "Comment", target: comment
-            .btn-group
-              %button.btn.btn-link.btn-sm.dropdown-toggle{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
+            .dropdown.d-inline
+              %button.btn.btn-link.answerbox__action.dropdown-toggle{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
                 %span.caret
               = render "actions/comment", comment: comment, answer: a

--- a/spec/views/answerbox/_comments.html.haml_spec.rb
+++ b/spec/views/answerbox/_comments.html.haml_spec.rb
@@ -40,7 +40,7 @@ describe "answerbox/_comments.html.haml", type: :view do
 
     it "shows the delete option" do
       html = Nokogiri::HTML.parse(rendered)
-      selector = %(li.comment[data-comment-id="#{comment.id}"] .btn-group a[data-action="ab-comment-destroy"])
+      selector = %(li.comment[data-comment-id="#{comment.id}"] .dropdown a[data-action="ab-comment-destroy"])
       element = html.css(selector)
       expect(element).to_not be_nil
       expect(element.text.strip).to eq("Delete")
@@ -57,7 +57,7 @@ describe "answerbox/_comments.html.haml", type: :view do
 
     it "does not show the delete option" do
       html = Nokogiri::HTML.parse(rendered)
-      selector = %(li.comment[data-comment-id="#{comment.id}"] .btn-group a[data-action="ab-comment-destroy"])
+      selector = %(li.comment[data-comment-id="#{comment.id}"] .dropdown a[data-action="ab-comment-destroy"])
       expect(html.css(selector)).to be_empty
     end
   end


### PR DESCRIPTION
Fixes #1640 

Adjusts the `answerbox__action` class to now use the `raised-text` CSS variable, making it utilize the same color as the card text, which probably is expected anyway.

![image](https://github.com/Retrospring/retrospring/assets/1774242/8232df33-04c7-484d-8529-a299bdd909fe)

While fixing this I also made further adjustments to actions giving them a more uniform spacing and fixing misuse of the `btn-group` classes for dropdowns.