### PR TITLE
Adjust what content gets hidden on banned user profiles

### DIFF
--- a/app/views/layouts/user/profile.html.haml
+++ b/app/views/layouts/user/profile.html.haml
@@ -8,8 +8,9 @@
       .d-none.d-sm-block= render 'shared/links'
     .col-lg-9.col-md-8.col-xs-12.col-sm-8
       = render 'questionbox', user: @user
-      = render 'tabs/profile', user: @user
-      = yield
+      - unless @user.banned?
+        = render 'tabs/profile', user: @user
+        = yield
 - if user_signed_in?
   = render 'modal/list', user: @user
   - if current_user.mod? && @user != current_user

--- a/app/views/user/_profile.html.haml
+++ b/app/views/user/_profile.html.haml
@@ -37,4 +37,5 @@
       .profile__location
         %i.fa.fa-fw.fa-location-arrow
         = user.profile.location
-    = render "user/actions", user: user, type: :follower
+    - unless user.banned?
+      = render "user/actions", user: user, type: :follower

--- a/app/views/user/_profile.html.haml
+++ b/app/views/user/_profile.html.haml
@@ -37,5 +37,5 @@
       .profile__location
         %i.fa.fa-fw.fa-location-arrow
         = user.profile.location
-    - unless user.banned?
+    - unless user.banned? && !current_user&.mod?
       = render "user/actions", user: user, type: :follower

--- a/app/views/user/show.html.haml
+++ b/app/views/user/show.html.haml
@@ -1,17 +1,16 @@
-- unless @user.banned?
-  %div{ data: { controller: "navigation" } }
-    %button.d-none{ data: { hotkey: "j", action: "navigation#down" } }
-    %button.d-none{ data: { hotkey: "k", action: "navigation#up" } }
-    #pinned-answers
-      - @pinned_answers.each do |a|
-        = render "answerbox", a:
+%div{ data: { controller: "navigation" } }
+  %button.d-none{ data: { hotkey: "j", action: "navigation#down" } }
+  %button.d-none{ data: { hotkey: "k", action: "navigation#up" } }
+  #pinned-answers
+    - @pinned_answers.each do |a|
+      = render "answerbox", a:
 
-    #answers
-      - if @answers.empty?
-        = render "shared/empty", icon: "fa-regular fa-comments", translation_key: ".user.answers"
+  #answers
+    - if @answers.empty?
+      = render "shared/empty", icon: "fa-regular fa-comments", translation_key: ".user.answers"
 
-      - @answers.each do |a|
-        = render "answerbox", a:
+    - @answers.each do |a|
+      = render "answerbox", a:
 
 - if @more_data_available
   .d-flex.justify-content-center.justify-content-sm-start#paginator


### PR DESCRIPTION
This PR fixes the somewhat "broken" banned profiles. Since they still show the tab navigation and the pagination button. These are now properly hidden, as well as user actions.

![image](https://github.com/Retrospring/retrospring/assets/1774242/608aeb28-d79c-4f0c-9c58-d4ea29081a6c)
