### PR TITLE
Add support for sharing answers to Bluesky

### DIFF
--- a/app/controllers/ajax/answer_controller.rb
+++ b/app/controllers/ajax/answer_controller.rb
@@ -73,6 +73,7 @@ class Ajax::AnswerController < AjaxController
     url:      answer_share_url(answer),
     text:     prepare_tweet(answer, nil, true),
     twitter:  twitter_share_url(answer),
+    bluesky:  bluesky_share_url(answer),
     tumblr:   tumblr_share_url(answer),
     telegram: telegram_share_url(answer),
     custom:   CGI.escape(prepare_tweet(answer)),

--- a/app/helpers/social_helper.rb
+++ b/app/helpers/social_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module SocialHelper
+  include SocialHelper::BlueskyMethods
   include SocialHelper::TwitterMethods
   include SocialHelper::TumblrMethods
   include SocialHelper::TelegramMethods

--- a/app/helpers/social_helper/bluesky_methods.rb
+++ b/app/helpers/social_helper/bluesky_methods.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "cgi"
+
+module SocialHelper::BlueskyMethods
+  def bluesky_share_url(answer)
+    "https://bsky.app/intent/compose?text=#{CGI.escape(prepare_tweet(answer))}"
+  end
+end

--- a/app/javascript/retrospring/controllers/inbox_sharing_controller.ts
+++ b/app/javascript/retrospring/controllers/inbox_sharing_controller.ts
@@ -1,9 +1,10 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-  static targets = ['twitter', 'tumblr', 'telegram', 'other', 'custom', 'clipboard'];
+  static targets = ['twitter', 'bluesky', 'tumblr', 'telegram', 'other', 'custom', 'clipboard'];
 
   declare readonly twitterTarget: HTMLAnchorElement;
+  declare readonly blueskyTarget: HTMLAnchorElement;
   declare readonly tumblrTarget: HTMLAnchorElement;
   declare readonly telegramTarget: HTMLAnchorElement;
   declare readonly customTarget: HTMLAnchorElement;
@@ -22,6 +23,7 @@ export default class extends Controller {
   connect(): void {
     if (this.autoCloseValue) {
       this.twitterTarget.addEventListener('click', () => this.close());
+      this.blueskyTarget.addEventListener('click', () => this.close());
       this.tumblrTarget.addEventListener('click', () => this.close());
       this.telegramTarget.addEventListener('click', () => this.close());
       this.otherTarget.addEventListener('click', () => this.closeAfterShare());
@@ -41,6 +43,7 @@ export default class extends Controller {
     this.element.classList.remove('d-none');
 
     this.twitterTarget.href = this.configValue['twitter'];
+    this.blueskyTarget.href = this.configValue['bluesky'];
     this.tumblrTarget.href = this.configValue['tumblr'];
     this.telegramTarget.href = this.configValue['telegram'];
 

--- a/app/views/actions/_share.html.haml
+++ b/app/views/actions/_share.html.haml
@@ -2,6 +2,9 @@
   %a.dropdown-item{ href: twitter_share_url(answer), target: "_blank" }
     %i.fa.fa-fw.fa-twitter
     = t(".twitter")
+  %a.dropdown-item{ href: bluesky_share_url(answer), target: "_blank" }
+    %i.fa.fa-fw.fa-cloud
+    = t(".bluesky")
   %a.dropdown-item{ href: tumblr_share_url(answer), target: "_blank" }
     %i.fa.fa-fw.fa-tumblr
     = t(".tumblr")

--- a/app/views/inbox/_entry.html.haml
+++ b/app/views/inbox/_entry.html.haml
@@ -21,9 +21,12 @@
         .align-self-center
           %p.fs-3.fw-bold= t(".sharing.heading")
           %p
-            %a.btn.btn-primary.mb-1{ href: "https://twitter.com/intent/tweet?text=", data: { inbox_sharing_target: "twitter" }, target: "_blank" }
+            %a.btn.btn-primary.mb-1{ href: "#", data: { inbox_sharing_target: "twitter" }, target: "_blank" }
               %i.fab.fa-twitter.fa-fw
               Twitter
+            %a.btn.btn-primary.mb-1{ href: "#", data: { inbox_sharing_target: "bluesky" }, target: "_blank" }
+              %i.fas.fa-cloud.fa-fw
+              Bluesky
             %a.btn.btn-primary.mb-1{ href: "#", data: { inbox_sharing_target: "tumblr" }, target: "_blank" }
               %i.fab.fa-tumblr.fa-fw
               Tumblr

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -79,6 +79,7 @@ en:
       pin: "Pin to Profile"
       unpin: "Unpin from Profile"
     share:
+      bluesky: "Share on Bluesky"
       copy: "Copy to Clipboard"
       twitter: "Share on Twitter"
       tumblr: "Share on Tumblr"

--- a/spec/controllers/ajax/answer_controller_spec.rb
+++ b/spec/controllers/ajax/answer_controller_spec.rb
@@ -176,6 +176,7 @@ describe Ajax::AnswerController, :ajax_controller, type: :controller do
                     "url"      => a_string_matching("https://#{APP_CONFIG['hostname']}/"),
                     "text"     => a_string_matching("Werfen Sie nicht länger das Fenster zum Geld hinaus!"),
                     "twitter"  => a_string_matching("https://twitter.com/"),
+                    "bluesky"  => a_string_matching("https://bsky.app/"),
                     "tumblr"   => a_string_matching("https://www.tumblr.com/"),
                     "telegram" => a_string_matching("https://t.me/"),
                     "custom"   => a_string_matching(/Werfen\+Sie\+nicht\+l%C3%A4nger\+das\+Fenster\+zum\+Geld\+hinaus%21/),

--- a/spec/controllers/ajax/answer_controller_spec.rb
+++ b/spec/controllers/ajax/answer_controller_spec.rb
@@ -94,6 +94,7 @@ describe Ajax::AnswerController, :ajax_controller, type: :controller do
                     "url"      => a_string_matching("https://#{APP_CONFIG['hostname']}/"),
                     "text"     => a_string_matching("Werfen Sie nicht länger das Fenster zum Geld hinaus!"),
                     "twitter"  => a_string_matching("https://twitter.com/"),
+                    "bluesky"  => a_string_matching("https://bsky.app/"),
                     "tumblr"   => a_string_matching("https://www.tumblr.com/"),
                     "telegram" => a_string_matching("https://t.me/"),
                     "custom"   => a_string_matching(/Werfen\+Sie\+nicht\+l%C3%A4nger\+das\+Fenster\+zum\+Geld\+hinaus%21/),

--- a/spec/helpers/social_helper/bluesky_methods_spec.rb
+++ b/spec/helpers/social_helper/bluesky_methods_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SocialHelper::BlueskyMethods, type: :helper do
+  let(:user) { FactoryBot.create(:user) }
+  let(:question_content) { "q" * 255 }
+  let(:answer_content) { "a" * 255 }
+  let(:answer) do
+    FactoryBot.create(:answer, user:,
+                               content:          answer_content,
+                               question_content:,)
+  end
+
+  before do
+    stub_const("APP_CONFIG", {
+                 "hostname"       => "example.com",
+                 "https"          => true,
+                 "items_per_page" => 5,
+               },)
+  end
+
+  describe "#bluesky_share_url" do
+    subject { bluesky_share_url(answer) }
+
+    it "should return a proper share link" do
+      expect(subject).to eq("https://bsky.app/intent/compose?text=#{CGI.escape(prepare_tweet(answer))}")
+    end
+  end
+end

--- a/spec/helpers/social_helper/bluesky_methods_spec.rb
+++ b/spec/helpers/social_helper/bluesky_methods_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe SocialHelper::BlueskyMethods, type: :helper do
+  include SocialHelper::TwitterMethods
+
   let(:user) { FactoryBot.create(:user) }
   let(:question_content) { "q" * 255 }
   let(:answer_content) { "a" * 255 }


### PR DESCRIPTION
Fixes #1645

In post-answering dialog in inbox:
![image](https://github.com/Retrospring/retrospring/assets/1774242/168eff25-36c1-4211-b6b4-e28e65d64022)

In the sharing menu on answers:
![image](https://github.com/Retrospring/retrospring/assets/1774242/b57b2c77-631b-45dd-bba0-94887fefc729)

Using a cloud at the moment because Blueskys branding is not in Font Awesome yet.