### PR TITLE
Improve layout of answerboxes

### DIFF
--- a/app/assets/stylesheets/components/_inbox-entry.scss
+++ b/app/assets/stylesheets/components/_inbox-entry.scss
@@ -23,6 +23,10 @@
       .text-muted {
         color: RGBA(var(--primary-text), 0.8) !important;
       }
+
+      .btn {
+        color: inherit;
+      }
     }
   }
 

--- a/app/assets/stylesheets/components/_question.scss
+++ b/app/assets/stylesheets/components/_question.scss
@@ -10,8 +10,11 @@
   &__text,
   &__user {
     margin-bottom: 0;
-    overflow: hidden;
     word-break: break-word;
+  }
+
+  &__text {
+    overflow: hidden;
   }
 
   &--sticky {

--- a/app/components/question_component/question_component.html.haml
+++ b/app/components/question_component/question_component.html.haml
@@ -17,11 +17,8 @@
         ·
         %a{ href: question_path(@question.user.screen_name, @question.id), data: { selection_hotkey: "a" } }
           = t(".answers", count: @question.answer_count)
-        ·
-        = time_tooltip(@question)
-      - else
-        ·
-        = link_to(time_tooltip(@question), question_path(@question.user.screen_name, @question.id))
+      ·
+      = time_tooltip(@question)
       - if user_signed_in?
         .dropdown.d-inline
           %button.btn.btn-link.btn-sm.p-0{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }

--- a/app/components/question_component/question_component.html.haml
+++ b/app/components/question_component/question_component.html.haml
@@ -12,19 +12,23 @@
           %i.fa.fa-eye-slash{ data: { bs_toggle: "tooltip", bs_title: t(".visible_to_you") } }
         - elsif moderation_view?
           %i.fa.fa-eye-slash{ data: { bs_toggle: "tooltip", bs_title: t(".visible_mod_mode") } }
-      = t(".asked_html", user: user_screen_name(@question.user, context_user: @context_user, author_identifier: author_identifier), time: time_tooltip(@question))
+      = user_screen_name(@question.user, context_user: @context_user, author_identifier: author_identifier)
       - if follower_question?
         ·
         %a{ href: question_path(@question.user.screen_name, @question.id), data: { selection_hotkey: "a" } }
           = t(".answers", count: @question.answer_count)
+        ·
+        = time_tooltip(@question)
+      - else
+        ·
+        = link_to(time_tooltip(@question), question_path(@question.user.screen_name, @question.id))
+      - if user_signed_in?
+        .dropdown.d-inline
+          %button.btn.btn-link.btn-sm.p-0{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
+            %i.fa.fa-fw.fa-ellipsis
+          = render "actions/question", question: @question
     .question__body{ data: { controller: @question.long? ? "collapse" : nil } }
       .question__text{ class: @question.long? && @collapse ? "collapsed" : "", data: { collapse_target: "content" } }
         = question_markdown @question.content
       - if @question.long? && @collapse
         = render "shared/collapse", type: "question"
-  - if user_signed_in?
-    .flex-shrink-0.ms-auto
-      .btn-group
-        %button.btn.btn-link.btn-sm.dropdown-toggle{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
-          %span.caret
-        = render "actions/question", question: @question

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -75,9 +75,6 @@ module BootstrapHelper
   def time_tooltip(subject, placement = "bottom")
     tooltip time_ago_in_words(subject.created_at), localize(subject.created_at), placement
   end
-
-  def hidespan(body, hide)
-    content_tag(:span, body, class: hide)
   end
 
   ##

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -73,8 +73,7 @@ module BootstrapHelper
   end
 
   def time_tooltip(subject, placement = "bottom")
-    tooltip time_ago_in_words(subject.created_at), localize(subject.created_at), placement
-  end
+    tooltip time_ago_in_words(subject.created_at, scope: "datetime.distance_in_words.short"), localize(subject.created_at, format: :long), placement
   end
 
   ##

--- a/app/javascript/retrospring/initializers/bootstrap.ts
+++ b/app/javascript/retrospring/initializers/bootstrap.ts
@@ -11,7 +11,7 @@ export default function (): void {
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
     [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
 
-    const dropdownElementList = document.querySelectorAll('.dropdown-toggle');
+    const dropdownElementList = document.querySelectorAll('[data-bs-toggle="dropdown"]');
     [...dropdownElementList].map(dropdownToggleEl => new bootstrap.Dropdown(dropdownToggleEl));
 
     // HACK/BUG?: Bootstrap disables dropdowns in navbars, here we re-enable and "kinda" fix it

--- a/app/views/answerbox/_actions.html.haml
+++ b/app/views/answerbox/_actions.html.haml
@@ -12,6 +12,6 @@
   = render "actions/share", answer: a
 - if user_signed_in?
   .dropdown.d-inline
-    %button.btn.btn-link.answerbox__action.dropdown-toggle{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
-      %span.caret
+    %button.btn.btn-link.answerbox__action{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
+      %i.fa.fa-fw.fa-ellipsis
     = render "actions/answer", answer: a

--- a/app/views/answerbox/_comments.html.haml
+++ b/app/views/answerbox/_comments.html.haml
@@ -21,6 +21,6 @@
             - else
               = render "reactions/create", type: "Comment", target: comment
             .dropdown.d-inline
-              %button.btn.btn-link.answerbox__action.dropdown-toggle{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
-                %span.caret
+              %button.btn.btn-link.answerbox__action{ data: { bs_toggle: :dropdown }, aria: { expanded: false } }
+                %i.fa.fa-fw.fa-ellipsis
               = render "actions/comment", comment: comment, answer: a

--- a/app/views/application/_answerbox.html.haml
+++ b/app/views/application/_answerbox.html.haml
@@ -20,6 +20,11 @@
               = user_screen_name(a.user)
               ·
               = link_to(time_tooltip(a), answer_path(a.user.screen_name, a.id), data: { selection_hotkey: "l" })
+              - if a.pinned_at.present?
+                %span.answerbox__pinned
+                  ·
+                  %i.fa.fa-thumbtack
+                  = t(".pinned")
       .d-flex.d-md-block.answerbox__actions.ms-auto
         = render "answerbox/actions", a:, display_all:
   .card-footer{ id: "ab-comments-section-#{a.id}", class: display_all.nil? ? "d-none" : nil }

--- a/app/views/application/_answerbox.html.haml
+++ b/app/views/application/_answerbox.html.haml
@@ -9,27 +9,6 @@
         = markdown a.content
       - if a.long? && !display_all
         = render "shared/collapse", type: "answer"
-    - if @user.nil?
-      .row
-        .col-sm-6.text-start.text-muted
-          .d-flex
-            .flex-shrink-0
-              %a{ href: user_path(a.user) }
-                = render AvatarComponent.new(user: a.user, size: "sm", classes: ["answerbox__answer-user-avatar"])
-            .flex-grow-1
-              %h6.answerbox__answer-user
-                = raw t(".answered", hide: hidespan(t(".hide"), "d-none d-sm-inline"), user: user_screen_name(a.user))
-              .answerbox__answer-date
-                = link_to(raw(t("time.distance_ago", time: time_tooltip(a))), answer_path(a.user.screen_name, a.id), data: { selection_hotkey: "l" })
-        .col-md-6.d-flex.d-md-block.answerbox__actions
-          = render "answerbox/actions", a:, display_all:
-    - else
-      .row
-        .col-md-6.text-start.text-muted
-          %i.fa.fa-clock-o
-          = link_to(raw(t("time.distance_ago", time: time_tooltip(a))), answer_path(a.user.screen_name, a.id), class: "answerbox__permalink")
-          - if a.pinned_at.present?
-            %span.answerbox__pinned
               ·
               %i.fa.fa-thumbtack
               = t(".pinned")

--- a/app/views/application/_answerbox.html.haml
+++ b/app/views/application/_answerbox.html.haml
@@ -9,11 +9,19 @@
         = markdown a.content
       - if a.long? && !display_all
         = render "shared/collapse", type: "answer"
+    .d-md-flex
+      .text-muted
+        .d-flex.align-items-center
+          .flex-shrink-0
+            %a{ href: user_path(a.user) }
+              = render AvatarComponent.new(user: a.user, size: "sm", classes: ["answerbox__answer-user-avatar"])
+          .flex-grow-1
+            %h6.answerbox__answer-user
+              = user_screen_name(a.user)
               ·
-              %i.fa.fa-thumbtack
-              = t(".pinned")
-        .col-md-6.d-md-flex.answerbox__actions
-          = render "answerbox/actions", a:, display_all:
+              = link_to(time_tooltip(a), answer_path(a.user.screen_name, a.id), data: { selection_hotkey: "l" })
+      .d-flex.d-md-block.answerbox__actions.ms-auto
+        = render "answerbox/actions", a:, display_all:
   .card-footer{ id: "ab-comments-section-#{a.id}", class: display_all.nil? ? "d-none" : nil }
     = turbo_frame_tag("ab-reactions-list-#{a.id}", src: reactions_path(a.question, a), loading: :lazy) do
       .d-flex.smiles

--- a/app/views/reactions/_create.html.haml
+++ b/app/views/reactions/_create.html.haml
@@ -5,7 +5,7 @@
                       data: { controller: :reaction, action: "turbo:submit-start->reaction#disable turbo:submit-end->reaction#enable" } },
               class: "btn btn-link answerbox__action smile",
               data: { reaction_target: :button } do
-    %i.fa.fa-fw.fa-smile-o
+    %i.fa.fa-smile-o
     %span= target.smile_count
 
 - if type == "Comment"
@@ -15,5 +15,5 @@
                       data: { controller: :reaction, action: "turbo:submit-start->reaction#disable turbo:submit-end->reaction#enable" } },
               class: "btn btn-link answerbox__action smile",
               data: { reaction_target: :button } do
-    %i.fa.fa-fw.fa-smile-o
+    %i.fa.fa-smile-o
     %span= target.smile_count

--- a/app/views/reactions/_destroy.html.haml
+++ b/app/views/reactions/_destroy.html.haml
@@ -6,7 +6,7 @@
                       data: { controller: :reaction, action: "turbo:submit-start->reaction#disable turbo:submit-end->reaction#enable" } },
               class: "btn btn-link answerbox__action unsmile",
               data: { reaction_target: :button } do
-    %i.fa.fa-fw.fa-smile-o
+    %i.fa.fa-smile-o
     %span= target.smile_count
 
 - if type == "Comment"
@@ -17,5 +17,5 @@
                       data: { controller: :reaction, action: "turbo:submit-start->reaction#disable turbo:submit-end->reaction#enable" } },
               class: "btn btn-link answerbox__action unsmile",
               data: { reaction_target: :button } do
-    %i.fa.fa-fw.fa-smile-o
+    %i.fa.fa-smile-o
     %span= target.smile_count

--- a/config/locales/voc.en.yml
+++ b/config/locales/voc.en.yml
@@ -42,3 +42,43 @@ en:
     days: "days"
     weeks: "weeks"
     months: "months"
+  datetime:
+    distance_in_words:
+      short:
+        about_x_hours:
+          one: "1h"
+          other: "%{count}h"
+        about_x_months:
+          one: "1mo"
+          other: "%{count}mo"
+        about_x_years:
+          one: "1y"
+          other: "%{count}y"
+        almost_x_years:
+          one: "1y"
+          other: "%{count}y"
+        half_a_minute: 1m
+        less_than_x_seconds:
+          one: "1s"
+          other: "%{count}s"
+        less_than_x_minutes:
+          one: "1m"
+          other: "%{count}m"
+        over_x_years:
+          one: "1y"
+          other: "%{count}y"
+        x_seconds:
+          one: "1s"
+          other: "%{count}s"
+        x_minutes:
+          one: "1m"
+          other: "%{count}m"
+        x_days:
+          one: "1d"
+          other: "%{count}d"
+        x_months:
+          one: "1mo"
+          other: "%{count}mo"
+        x_years:
+          one: "1y"
+          other: "%{count}y"

--- a/spec/helpers/bootstrap_helper_spec.rb
+++ b/spec/helpers/bootstrap_helper_spec.rb
@@ -103,14 +103,8 @@ describe BootstrapHelper, type: :helper do
         @user = FactoryBot.create(:user)
         travel 10.minutes
 
-        expect(time_tooltip(@user)).to eq("<span title=\"Sun, 01 Jan 1984 00:00:00 +0000\" data-bs-toggle=\"tooltip\" data-bs-placement=\"bottom\">10 minutes</span>")
+        expect(time_tooltip(@user)).to eq("<span title=\"January 01, 1984 00:00\" data-bs-toggle=\"tooltip\" data-bs-placement=\"bottom\">10m</span>")
       end
-    end
-  end
-
-  describe "#hidespan" do
-    it "should return the proper markup" do
-      expect(hidespan("Hidden Text", "d-none")).to eq("<span class=\"d-none\">Hidden Text</span>")
     end
   end
 end


### PR DESCRIPTION
Current answerbox layout:
![image](https://github.com/Retrospring/retrospring/assets/1774242/dcf4b842-962e-4fe1-9a51-19a07c647dea)

New answerbox layout:
![image](https://github.com/Retrospring/retrospring/assets/1774242/2d785166-49b6-4821-8252-35ff8ddab889)

Changes summarized:
* Removed profile specific layout of answerboxes (so it'll show the user on profiles as well)
* Adjusted date format of questions and answers to be short and relative, instead of a long form "[time] ago"
* Changed the icon of the "more actions" toggle to an ellipsis instead of the caret/triangle
* Moved the "more action" toggle of questions into the heading
* Questions are now linked, even if they don't have multiple answers
* Removed the fullwidth class from the smile icon, so it looks more consistent with the fullwidth icons from other answerbox actions (`fa-smile-o` is pretty wide with `fa-fw`)