### PR TITLE
 use time_tooltip for comments

### DIFF
--- a/app/views/answerbox/_comments.html.haml
+++ b/app/views/answerbox/_comments.html.haml
@@ -11,8 +11,9 @@
           .flex-grow-1
             %h6.comment__user
               = user_screen_name comment.user
-              %span.text-muted{ title: comment.created_at, data: { bs_toggle: :tooltip, bs_placement: :right } }
-                = t("time.distance_ago", time: time_ago_in_words(comment.created_at))
+              %span.text-muted
+                ·
+                = time_tooltip comment
             .comment__content
               = markdown comment.content
           .flex-shrink-0.ms-auto

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,6 +72,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # annotate rendered view with file names, really useful in dev!
+  config.action_view.annotate_rendered_view_with_filenames = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker


### PR DESCRIPTION
fixes #1650

the tooltip doesn't work though, but i suggest to fix this as part of #1658

obligatory screenshot:

<img width="878" alt="Screenshot 2024-03-09 at 14 38 33" src="https://github.com/Retrospring/retrospring/assets/1809170/05b64b23-41a4-4514-9075-e91678aec59d">