### PR TITLE
Use new date format in notifications

### DIFF
--- a/app/views/notifications/type/_answer.html.haml
+++ b/app/views/notifications/type/_answer.html.haml
@@ -6,8 +6,9 @@
       = render AvatarComponent.new(user: notification.target.user, size: "xs")
       = t(".heading_html",
           user: user_screen_name(notification.target.user),
-          question: link_to(t(".link_text"), answer_path(username: notification.target.user.screen_name, id: notification.target.id), target: "_top"),
-          time: time_tooltip(notification.target))
+          question: link_to(t(".link_text"), answer_path(username: notification.target.user.screen_name, id: notification.target.id), target: "_top"))
+      ·
+      = time_tooltip(notification.target)
     .list-group
       .list-group-item
         %h6.notification__list-heading= t("activerecord.models.question.one")

--- a/app/views/notifications/type/_comment.html.haml
+++ b/app/views/notifications/type/_comment.html.haml
@@ -10,16 +10,14 @@
               answer: link_to(t(".active.link_text"),
                               answer_path(username: notification.target.user.screen_name,
                               id: notification.target.answer.id),
-                              target: "_top"),
-              time: time_tooltip(notification.target))
+                              target: "_top"))
       - elsif notification.target.user == notification.target.answer.user
         = t(".heading_html",
               user: user_screen_name(notification.target.user),
               answer: link_to(t(".passive.link_text"),
                               answer_path(username: notification.target.user.screen_name,
                               id: notification.target.answer.id),
-                              target: "_top"),
-              time: time_tooltip(notification.target))
+                              target: "_top"))
       - else
         = t(".heading_html",
               user: user_screen_name(notification.target.user),
@@ -27,8 +25,9 @@
                                 user: user_screen_name(notification.target.answer.user, url: false)),
                                 answer_path(username: notification.target.user.screen_name,
                                 id: notification.target.answer.id),
-                                target: "_top"),
-              time: time_tooltip(notification.target))
+                                target: "_top"))
+      ·
+      = time_tooltip(notification.target)
     .list-group
       .list-group-item
         %h6.notification__list-heading= t("activerecord.models.answer.one")

--- a/app/views/notifications/type/_reaction.html.haml
+++ b/app/views/notifications/type/_reaction.html.haml
@@ -10,16 +10,16 @@
               type: link_to(t(".#{notification.target.parent_type.downcase}.link_text"),
                               answer_path(username: notification.target.user.screen_name,
                               id: notification.target.parent.id),
-                              target: "_top"),
-              time: time_tooltip(notification.target))
+                              target: "_top"))
       - elsif notification.target.parent_type == "Comment"
         = t(".heading_html",
               user: user_screen_name(notification.target.user),
               type: link_to(t(".#{notification.target.parent_type.downcase}.link_text"),
                               answer_path(username: notification.target.user.screen_name,
                               id: notification.target.parent.answer.id),
-                              target: "_top"),
-              time: time_tooltip(notification.target))
+                              target: "_top"))
+      ·
+      = time_tooltip(notification.target)
     .list-group
       .list-group-item
         %h6.notification__list-heading= t("activerecord.models.#{notification.target.parent_type.downcase}.one")

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -343,10 +343,10 @@ en:
       none: "No new notifications."
     type:
       answer:
-        heading_html: "%{user} answered %{question} %{time} ago"
+        heading_html: "%{user} answered %{question}"
         link_text: "your question"
       comment:
-        heading_html: "%{user} commented on %{answer} %{time} ago"
+        heading_html: "%{user} commented on %{answer}"
         active:
           link_text: "your answer"
         passive:
@@ -358,7 +358,7 @@ en:
         text_html: "Head over to %{settings_export} to download it."
         settings_export: "the settings page"
       reaction:
-        heading_html: "%{user} smiled %{type} %{time} ago"
+        heading_html: "%{user} smiled %{type}"
         answer:
           link_text: "your answer"
         comment:


### PR DESCRIPTION
Switched this up for all notification types, except for follows, as `time_ago_in_words` looks fine in the notification body.

![image](https://github.com/Retrospring/retrospring/assets/1774242/d34fdba0-6588-4193-83e5-c41729706592)
