### PR TITLE
Add max question content limit of 32,768 characters

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,6 +11,7 @@ class Question < ApplicationRecord
   validates :content, length: { minimum: 1 }
 
   SHORT_QUESTION_MAX_LENGTH = 512
+  LONG_QUESTION_MAX_LENGTH = 32768
 
   before_destroy do
     rep = Report.where(target_id: self.id, type: "Reports::Question")

--- a/config/locales/errors.en.yml
+++ b/config/locales/errors.en.yml
@@ -37,3 +37,5 @@ en:
     record_not_found: "Record not found"
 
     not_authorized: "You need to be logged in to perform this action"
+
+    question_too_long: "Question is too long"

--- a/lib/use_case/question/create.rb
+++ b/lib/use_case/question/create.rb
@@ -65,6 +65,7 @@ module UseCase
       def check_user
         raise Errors::NotAuthorized if target_user.privacy_require_user && !source_user_id
         raise Errors::QuestionTooLong if content.length > ::Question::SHORT_QUESTION_MAX_LENGTH && !target_user.profile.allow_long_questions
+        raise Errors::QuestionTooLong if content.length > ::Question::LONG_QUESTION_MAX_LENGTH && target_user.profile.allow_long_questions
       end
 
       def create_question

--- a/lib/use_case/question/create_followers.rb
+++ b/lib/use_case/question/create_followers.rb
@@ -9,6 +9,8 @@ module UseCase
       option :send_to_own_inbox, type: Types::Params::Bool, default: proc { false }
 
       def call
+        check_question
+
         question = ::Question.create!(
           content:,
           author_is_anonymous: false,
@@ -31,6 +33,10 @@ module UseCase
       end
 
       private
+
+      def check_question
+        raise Errors::QuestionTooLong if content.length > ::Question::LONG_QUESTION_MAX_LENGTH
+      end
 
       def increment_asked_count
         source_user.increment(:asked_count)

--- a/spec/lib/use_case/question/create_followers_spec.rb
+++ b/spec/lib/use_case/question/create_followers_spec.rb
@@ -36,5 +36,13 @@ describe UseCase::Question::CreateFollowers do
     it "increments the asked count" do
       expect { subject }.to change { source_user.reload.asked_count }.by(1)
     end
+
+    context "content is over 32768 characters long" do
+      let(:content) { "a" * 32769 }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::QuestionTooLong)
+      end
+    end
   end
 end

--- a/spec/lib/use_case/question/create_spec.rb
+++ b/spec/lib/use_case/question/create_spec.rb
@@ -75,6 +75,27 @@ describe UseCase::Question::Create do
         it_behaves_like "creates the question"
       end
     end
+
+    context "content is over 32768 characters long" do
+      let(:content) { "a" * 32769 }
+
+      context "recipient does not allow long questions" do
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::QuestionTooLong)
+        end
+      end
+
+      context "recipient allows long questions" do
+        before do
+          target_user.profile.allow_long_questions = true
+          target_user.profile.save
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::QuestionTooLong)
+        end
+      end
+    end
   end
 
   shared_examples "filters questions" do


### PR DESCRIPTION
Adds a maximum character limit to questions regardless of the picked setting. Using over 32768 characters (number picked because 512 is also a power of 2) will now also raise `Errors:QuestionTooLong`.