### PR TITLE
Fix error when trying to smile already smiled records

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -19,7 +19,7 @@ class ReactionsController < ApplicationController
     target = target_class.find(params[:id])
 
     UseCase::Reaction::Create.call(
-      source_user: current_user,
+      source_user_id: current_user.id,
       target:,
     )
 
@@ -43,7 +43,7 @@ class ReactionsController < ApplicationController
     target = target_class.find(params[:id])
 
     UseCase::Reaction::Destroy.call(
-      source_user: current_user,
+      source_user_id: current_user.id,
       target:,
     )
 

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,8 +1,6 @@
 class Answer < ApplicationRecord
   extend Answer::TimelineMethods
 
-  attr_accessor :has_reacted, :is_subscribed
-
   belongs_to :user, counter_cache: :answered_count
   belongs_to :question, counter_cache: :answer_count
   has_many :comments, dependent: :destroy

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,6 +1,8 @@
 class Answer < ApplicationRecord
   extend Answer::TimelineMethods
 
+  attr_accessor :has_reacted, :is_subscribed
+
   belongs_to :user, counter_cache: :answered_count
   belongs_to :question, counter_cache: :answer_count
   has_many :comments, dependent: :destroy

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -71,4 +71,8 @@ class Answer < ApplicationRecord
   def long? = content.length > SHORT_ANSWER_MAX_LENGTH
 
   def pinned? = pinned_at.present?
+
+  def has_reacted = self.attributes["has_reacted"] || false
+
+  def is_subscribed = self.attributes["is_subscribed"] || false
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -4,6 +4,8 @@ class Reaction < ApplicationRecord
   belongs_to :parent, polymorphic: true
   belongs_to :user
 
+  validates_uniqueness_of :parent_id, :scope => :user_id
+
   # rubocop:disable Rails/SkipsModelValidations
   after_create do
     Notification.notify parent.user, self unless parent.user == user

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -4,7 +4,7 @@ class Reaction < ApplicationRecord
   belongs_to :parent, polymorphic: true
   belongs_to :user
 
-  validates_uniqueness_of :parent_id, :scope => :user_id
+  validates :parent_id, uniqueness: { scope: :user_id }
 
   # rubocop:disable Rails/SkipsModelValidations
   after_create do

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -54,6 +54,8 @@ en:
         success_text: "Success text colour"
         warning_color: "Warning colour"
         warning_text: "Warning text colour"
+      reaction:
+        parent_id: "Target"
       user:
         created_at: "Account created at"
         current_password: "Current password"
@@ -107,6 +109,11 @@ en:
     errors:
       messages:
         invalid_url: "does not look like a valid URL"
+      models:
+        reaction:
+          attributes:
+            parent_id:
+              taken: "already smiled"
   helpers:
     submit:
       user:

--- a/lib/use_case/reaction/create.rb
+++ b/lib/use_case/reaction/create.rb
@@ -3,7 +3,7 @@
 module UseCase
   module Reaction
     class Create < UseCase::Base
-      option :source_user, type: Types.Instance(::User)
+      option :source_user_id, type: Types::Coercible::Integer
       option :target, type: Types.Instance(::Answer) | Types.Instance(::Comment)
       option :content, type: Types::Coercible::String, optional: true
 
@@ -14,6 +14,12 @@ module UseCase
           status:   201,
           resource: reaction,
         }
+      end
+
+      private
+
+      def source_user
+        @source_user ||= ::User.find(source_user_id)
       end
     end
   end

--- a/lib/use_case/reaction/destroy.rb
+++ b/lib/use_case/reaction/destroy.rb
@@ -3,7 +3,7 @@
 module UseCase
   module Reaction
     class Destroy < UseCase::Base
-      option :source_user, type: Types.Instance(::User)
+      option :source_user_id, type: Types::Coercible::Integer
       option :target, type: Types.Instance(::Answer) | Types.Instance(::Comment)
 
       def call
@@ -13,6 +13,12 @@ module UseCase
           status:   204,
           resource: nil,
         }
+      end
+
+      private
+
+      def source_user
+        @source_user ||= ::User.find(source_user_id)
       end
     end
   end

--- a/spec/lib/use_case/reaction/create_spec.rb
+++ b/spec/lib/use_case/reaction/create_spec.rb
@@ -9,7 +9,7 @@ describe UseCase::Reaction::Create do
     end
   end
 
-  subject { UseCase::Reaction::Create.call(source_user: user, target:) }
+  subject { UseCase::Reaction::Create.call(source_user_id: user.id, target:) }
 
   let(:user) { FactoryBot.create(:user) }
 

--- a/spec/lib/use_case/reaction/destroy_spec.rb
+++ b/spec/lib/use_case/reaction/destroy_spec.rb
@@ -13,7 +13,7 @@ describe UseCase::Reaction::Destroy do
     end
   end
 
-  subject { UseCase::Reaction::Destroy.call(source_user: user, target:) }
+  subject { UseCase::Reaction::Destroy.call(source_user_id: user.id, target:) }
 
   let(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
Fixes #1673 

Multiple things that went wrong here:
* The scoped subquery thing never really worked (apparently), ActiveRecord never maps the `as` specified selects to the accessors, so they always are `false` (or `nil`)
  * This has been fixed with trying to pull the values we managed to fetch from `self.attributes`, because they are _IN THERE_. 
* Reactions didn't have a scoped uniqueness validation, so we always ran into a Postgres exception with the indices.
* Not sure if just locally, but at least noticed here, for some reason `User` coercion sometimes fails in use cases and breaks so badly the app needs to restart?
  * Fixed this with passing IDs into the Reaction use cases now and letting the use case resolve the source user.