### PR TITLE
questions: remove redundant or ungrammatical items

### DIFF
--- a/config/questions/en.yml
+++ b/config/questions/en.yml
@@ -259,12 +259,9 @@
           - song you listened to on repeat
           - thing you:
             - ate
+            - bought
             - did
-            - have:
-              - bought
-              - done
-              - eaten
-              - looked for
+            - looked for
     - your favourite song:
       - as a kid
       - from a few weeks ago
@@ -303,5 +300,4 @@
     - be the best player on a horrible team or the worst player on a great team
     - live in:
       - a city or in the countryside
-      - a flat or in a house
     - lose an arm or a leg


### PR DESCRIPTION
For a joke on my account, I decided to answer every possible generated question in one post. While doing that, I noticed that a number of questions were redundant - for example, "What is the last thing you ate?" and "What is the last thing you have eaten?" are the same question, except the latter is (I think) grammatically incorrect. Same with "Do you prefer to live in a house or a flat?" and "Would you rather live in a flat or a house?" So I went ahead and removed those questions.