### PR TITLE
Add ability to disable registrations

### DIFF
--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 class User::RegistrationsController < Devise::RegistrationsController
+  before_action :redirect_if_registrations_disabled!, only: %w[create new]
+
   def create
     if captcha_valid?
       super
     else
-      respond_with_navigational(resource){ redirect_to new_user_registration_path }
+      respond_with_navigational(resource) { redirect_to new_user_registration_path }
     end
   end
 
@@ -18,7 +22,7 @@ class User::RegistrationsController < Devise::RegistrationsController
     resource.destroy
     set_flash_message :notice, :destroyed if is_flashing_format?
     yield resource if block_given?
-    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+    respond_with_navigational(resource) { redirect_to after_sign_out_path_for(resource_name) }
   end
 
   private
@@ -28,5 +32,9 @@ class User::RegistrationsController < Devise::RegistrationsController
     return true unless APP_CONFIG.dig(:hcaptcha, :enabled)
 
     verify_hcaptcha
+  end
+
+  def redirect_if_registrations_disabled!
+    redirect_to root_path unless APP_CONFIG.dig(:features, :registration, :enabled)
   end
 end

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User::RegistrationsController < Devise::RegistrationsController
-  before_action :redirect_if_registrations_disabled!, only: %w[create new]
+  before_action :redirect_if_registrations_disabled!, only: %w[create new] # rubocop:disable Rails/LexicallyScopedActionFilter
 
   def create
     if captcha_valid?

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -35,6 +35,6 @@ class User::RegistrationsController < Devise::RegistrationsController
   end
 
   def redirect_if_registrations_disabled!
-    redirect_to root_path unless APP_CONFIG.dig(:features, :registration, :enabled)
+    redirect_to root_path unless Retrospring::Config.registrations_enabled?
   end
 end

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -5,7 +5,7 @@
       = render "layouts/messages"
       %h1= APP_CONFIG["site_name"]
       %p= t(".subtitle")
-      - if APP_CONFIG.dig(:features, :registration, :enabled)
+      - if Retrospring::Config.registrations_enabled?
         %p
           %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_registration_path) }
             = t(".register")

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -5,12 +5,18 @@
       = render "layouts/messages"
       %h1= APP_CONFIG["site_name"]
       %p= t(".subtitle")
-      %p
-        %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_registration_path) }
-          = t(".register")
-      %small
-        = t(".already_member")
-        = link_to t("voc.login"), new_user_session_path
+      - if APP_CONFIG.dig(:features, :registration, :enabled)
+        %p
+          %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_registration_path) }
+            = t(".register")
+        %small
+          = t(".already_member")
+          = link_to t("voc.login"), new_user_session_path
+      - else
+        %p
+          %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_session_path) }
+            = t("voc.login")
+
   .row.my-5.my-sm-10
     .col-sm-6.order-5.order-sm-1.text-center.text-sm-right
       %h2.mb-4= t(".questions.header")
@@ -77,12 +83,13 @@
         = t(".your_data.header")
       %p= t(".your_data.body", app_name: APP_CONFIG["site_name"])
 
-  .card
-    .card-body
-      %h2= t(".prompt.header")
-      %p= t(".prompt.body")
-      %p
-        %a.btn.btn-primary.btn-lg{ href: url_for(new_user_registration_path) }
-          = t(".register")
+  - if APP_CONFIG.dig(:features, :registration, :enabled)
+    .card
+      .card-body
+        %h2= t(".prompt.header")
+        %p= t(".prompt.body")
+        %p
+          %a.btn.btn-primary.btn-lg{ href: url_for(new_user_registration_path) }
+            = t(".register")
 
 = render "shared/links"

--- a/app/views/application/_questionbox.html.haml
+++ b/app/views/application/_questionbox.html.haml
@@ -40,24 +40,29 @@
                 %input{ name: "qb-to", type: "hidden", value: user.id }/
                 %button.btn.btn-primary{ name: "qb-ask",
                   type: :button,
-                  data: { loading_text: t(".load"), promote: user_signed_in? ? "false" : "true", "character-count-target": "action" } }
+                  data: { loading_text: t(".load"), promote: user_signed_in? || !user_signed_in? && !APP_CONFIG.dig(:features, :registration, :enabled) ? "false" : "true", "character-count-target": "action" } }
                   Ask
       - unless user_signed_in?
         - if user.privacy_allow_anonymous_questions?
-          .d-none#question-box-promote
-            .row
-              .col-12.text-center
-                %strong= t(".promote.message")
-            .row
-              .col-sm-5.offset-sm-1
-                .d-grid
-                  %button.btn.btn-primary#create-account= t(".promote.create")
-              .col-sm-5
-                .d-grid
-                  %button.btn.btn-default#new-question= t(".promote.another")
-            .row
-              .col-xs-12.col-sm-10.offset-sm-1.text-center
-                %small= t(".promote.join", app_title: APP_CONFIG["site_name"])
+          - if APP_CONFIG.dig(:features, :registration, :enabled)
+            .d-none#question-box-promote
+              .row
+                .col-12.text-center
+                  %strong= t(".promote.message")
+              .row
+                .col-sm-5.offset-sm-1
+                  .d-grid
+                    %button.btn.btn-primary#create-account= t(".promote.create")
+                .col-sm-5
+                  .d-grid
+                    %button.btn.btn-default#new-question= t(".promote.another")
+              .row
+                .col-xs-12.col-sm-10.offset-sm-1.text-center
+                  %small= t(".promote.join", app_title: APP_CONFIG["site_name"])
         - else
           .text-center
-            %strong= t(".status.non_anonymous_html", sign_in: link_to(t("voc.login"), new_user_session_path), sign_up: link_to(t("voc.register"), new_user_registration_path))
+            - if APP_CONFIG.dig(:features, :registration, :enabled)
+              %strong= t(".status.non_anonymous_html", sign_in: link_to(t("voc.login"), new_user_session_path), sign_up: link_to(t("voc.register"), new_user_registration_path))
+            - else
+              %strong= t(".status.non_anonymous_no_registration_html", sign_in: link_to(t("voc.login"), new_user_session_path))
+

--- a/app/views/application/_questionbox.html.haml
+++ b/app/views/application/_questionbox.html.haml
@@ -40,11 +40,11 @@
                 %input{ name: "qb-to", type: "hidden", value: user.id }/
                 %button.btn.btn-primary{ name: "qb-ask",
                   type: :button,
-                  data: { loading_text: t(".load"), promote: user_signed_in? || !user_signed_in? && !APP_CONFIG.dig(:features, :registration, :enabled) ? "false" : "true", "character-count-target": "action" } }
+                  data: { loading_text: t(".load"), promote: user_signed_in? || !user_signed_in? && !Retrospring::Config.registrations_enabled ? "false" : "true", "character-count-target": "action" } }
                   Ask
       - unless user_signed_in?
         - if user.privacy_allow_anonymous_questions?
-          - if APP_CONFIG.dig(:features, :registration, :enabled)
+          - if Retrospring::Config.registrations_enabled?
             .d-none#question-box-promote
               .row
                 .col-12.text-center
@@ -61,7 +61,7 @@
                   %small= t(".promote.join", app_title: APP_CONFIG["site_name"])
         - else
           .text-center
-            - if APP_CONFIG.dig(:features, :registration, :enabled)
+            - if Retrospring::Config.registrations_enabled?
               %strong= t(".status.non_anonymous_html", sign_in: link_to(t("voc.login"), new_user_session_path), sign_up: link_to(t("voc.register"), new_user_registration_path))
             - else
               %strong= t(".status.non_anonymous_no_registration_html", sign_in: link_to(t("voc.login"), new_user_session_path))

--- a/app/views/application/_questionbox.html.haml
+++ b/app/views/application/_questionbox.html.haml
@@ -19,10 +19,14 @@
         %strong= t(".status.locked")
     - elsif !user_signed_in? && user.privacy_require_user?
       .text-center
-        %strong= t(".status.require_user_html", sign_in: link_to(t("voc.login"), new_user_session_path), sign_up: link_to(t("voc.register"), new_user_registration_path))
+        %strong= t(".status.require_user_html",
+          sign_in: link_to(t("voc.login"), new_user_session_path),
+          sign_up: link_to(t("voc.register"), new_user_registration_path))
     - else
       - if user_signed_in? || user.privacy_allow_anonymous_questions?
-        #question-box{ data: user.profile.allow_long_questions ? {} : { controller: "character-count", "character-count-max-value": user.profile.question_length_limit }}
+        #question-box{
+            data: user.profile.allow_long_questions ? {} : { controller: "character-count", "character-count-max-value": user.profile.question_length_limit }
+          }
           %textarea.form-control{ name: "qb-question", placeholder: t(".placeholder"), data: { "character-count-target": "input" } }
           .row{ style: "padding-top: 5px;" }
             .col-6
@@ -36,11 +40,17 @@
                   %input{ name: "qb-anonymous", type: :hidden, value: false }/
             .col-6
               %p.pull-right
-                %span.text-muted.me-1{ class: user.profile.allow_long_questions ? "d-none" : "", data: { "character-count-target": "counter" } }= Question::SHORT_QUESTION_MAX_LENGTH
+                %span.text-muted.me-1{ class: user.profile.allow_long_questions ? "d-none" : "",
+                                       data: { "character-count-target": "counter" } }= Question::SHORT_QUESTION_MAX_LENGTH
                 %input{ name: "qb-to", type: "hidden", value: user.id }/
                 %button.btn.btn-primary{ name: "qb-ask",
                   type: :button,
-                  data: { loading_text: t(".load"), promote: user_signed_in? || !user_signed_in? && !Retrospring::Config.registrations_enabled ? "false" : "true", "character-count-target": "action" } }
+                  data: {
+                    loading_text: t(".load"),
+                    promote: user_signed_in? || !user_signed_in? && !Retrospring::Config.registrations_enabled ? "false" : "true",
+                    "character-count-target": "action"
+                    }
+                }
                   Ask
       - unless user_signed_in?
         - if user.privacy_allow_anonymous_questions?
@@ -62,7 +72,8 @@
         - else
           .text-center
             - if Retrospring::Config.registrations_enabled?
-              %strong= t(".status.non_anonymous_html", sign_in: link_to(t("voc.login"), new_user_session_path), sign_up: link_to(t("voc.register"), new_user_registration_path))
+              %strong= t(".status.non_anonymous_html",
+                sign_in: link_to(t("voc.login"), new_user_session_path),
+                sign_up: link_to(t("voc.register"), new_user_registration_path))
             - else
               %strong= t(".status.non_anonymous_no_registration_html", sign_in: link_to(t("voc.login"), new_user_session_path))
-

--- a/app/views/application/_questionbox.html.haml
+++ b/app/views/application/_questionbox.html.haml
@@ -19,9 +19,13 @@
         %strong= t(".status.locked")
     - elsif !user_signed_in? && user.privacy_require_user?
       .text-center
-        %strong= t(".status.require_user_html",
-          sign_in: link_to(t("voc.login"), new_user_session_path),
-          sign_up: link_to(t("voc.register"), new_user_registration_path))
+        - if Retrospring::Config.registrations_enabled?
+          %strong= t(".status.require_user_html",
+            sign_in: link_to(t("voc.login"), new_user_session_path),
+            sign_up: link_to(t("voc.register"), new_user_registration_path))
+        - else
+          %strong= t(".status.require_user_no_registration_html",
+            sign_in: link_to(t("voc.login"), new_user_session_path))
     - else
       - if user_signed_in? || user.privacy_allow_anonymous_questions?
         #question-box{

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -2,7 +2,7 @@
   = link_to 'Sign in', new_session_path(resource_name)
   %br/
 
-- if devise_mapping.registerable? && controller_name != 'registrations'
+- if devise_mapping.registerable? && controller_name != 'registrations' && Retrospring::Config.registrations_enabled?
   = link_to 'Sign up', new_registration_path(resource_name)
   %br/
 

--- a/app/views/navigation/_guest.html.haml
+++ b/app/views/navigation/_guest.html.haml
@@ -14,4 +14,5 @@
     .collapse.navbar-collapse#j2-main-navbar-collapse
       %ul.nav.navbar-nav.ms-auto
         = nav_entry t("voc.login"), new_user_session_path
-        = nav_entry t("voc.register"), new_user_registration_path
+        - if APP_CONFIG.dig(:features, :registration, :enabled)
+          = nav_entry t("voc.register"), new_user_registration_path

--- a/app/views/navigation/_guest.html.haml
+++ b/app/views/navigation/_guest.html.haml
@@ -14,5 +14,5 @@
     .collapse.navbar-collapse#j2-main-navbar-collapse
       %ul.nav.navbar-nav.ms-auto
         = nav_entry t("voc.login"), new_user_session_path
-        - if APP_CONFIG.dig(:features, :registration, :enabled)
+        - if Retrospring::Config.registrations_enabled?
           = nav_entry t("voc.register"), new_user_registration_path

--- a/config/initializers/10_config.rb
+++ b/config/initializers/10_config.rb
@@ -1,23 +1,4 @@
 # frozen_string_literal: true
 
 # Auxiliary config
-
-APP_CONFIG = {}.with_indifferent_access
-
-# load yml config if it's present
-justask_yml_path = Rails.root.join("config/justask.yml")
-APP_CONFIG.merge!(YAML.load_file(justask_yml_path)) if File.exist?(justask_yml_path)
-
-# load config from ENV where possible
-env_config = {
-  # The site name, shown everywhere
-  site_name: ENV.fetch("SITE_NAME", nil),
-
-  hostname:  ENV.fetch("HOSTNAME", nil),
-}.compact
-APP_CONFIG.merge!(env_config)
-
-# Update rails config for mail
-Rails.application.config.action_mailer.default_url_options = {
-  host: APP_CONFIG["hostname"],
-}
+APP_CONFIG = Retrospring::Config.config_hash

--- a/config/justask.yml.example
+++ b/config/justask.yml.example
@@ -52,6 +52,9 @@ features:
   # Public timeline
   public:
     enabled: true
+  # Registrations
+  registration:
+    enabled: true
 
 # Redis
 redis_url: "redis://localhost:6379"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -146,6 +146,9 @@ en:
         non_anonymous_html: |
           This user does not want to receive anonymous questions. <br/>
           (%{sign_in} or %{sign_up})
+        non_anonymous_no_registration_html: |
+          This user does not want to receive anonymous questions. <br/>
+          (%{sign_in})
   comment:
     show_reactions:
       title: "People who smiled this comment"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -143,6 +143,9 @@ en:
         require_user_html: |
           This user requires others to be logged in to ask questions. <br/>
           (%{sign_in} or %{sign_up})
+        require_user_no_registration_html: |
+          This user requires others to be logged in to ask questions. <br/>
+          (%{sign_in})
         non_anonymous_html: |
           This user does not want to receive anonymous questions. <br/>
           (%{sign_in} or %{sign_up})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
     # :registrations
     get "settings/delete_account" => "devise/registrations#cancel", :as => :cancel_user_registration
     post "/user/create" => "user/registrations#create", :as => :user_registration
-    get "/sign_up" => "devise/registrations#new", :as => :new_user_registration
+    get "/sign_up" => "user/registrations#new", :as => :new_user_registration
     get "/settings/account" => "devise/registrations#edit", :as => :edit_user_registration
     patch "/settings/account" => "devise/registrations#update", :as => :update_user_registration
     put "/settings/account" => "devise/registrations#update"

--- a/lib/retrospring/config.rb
+++ b/lib/retrospring/config.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Retrospring
+  module Config
+    module_function
+
+    def config_hash = {}.with_indifferent_access.tap do |hash|
+      # load yml config if it's present
+      justask_yml_path = Rails.root.join("config/justask.yml")
+      hash.merge!(YAML.load_file(justask_yml_path)) if File.exist?(justask_yml_path)
+
+      # load config from ENV where possible
+      env_config = {
+        # The site name, shown everywhere
+        site_name: ENV.fetch("SITE_NAME", nil),
+
+        hostname:  ENV.fetch("HOSTNAME", nil),
+      }.compact
+      hash.merge!(env_config)
+
+      # Update rails config for mail
+      Rails.application.config.action_mailer.default_url_options = {
+        host: hash["hostname"],
+      }
+    end
+
+    def registrations_enabled? = APP_CONFIG.dig(:features, :registration, :enabled)
+  end
+end

--- a/spec/controllers/user/registration_controller_spec.rb
+++ b/spec/controllers/user/registration_controller_spec.rb
@@ -15,14 +15,15 @@ describe User::RegistrationsController, type: :controller do
                    justask_admin retrospring_admin admin justask retrospring
                    moderation moderator mod administrator siteadmin site_admin
                    help retro_spring retroospring retrosprlng
-                 ]
-               })
+                 ],
+               },)
   end
 
   describe "#create" do
     context "valid user sign up" do
       before do
         allow(APP_CONFIG).to receive(:dig).with(:hcaptcha, :enabled).and_return(true)
+        allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(true)
         allow(controller).to receive(:verify_hcaptcha).and_return(captcha_successful)
       end
 
@@ -32,8 +33,8 @@ describe User::RegistrationsController, type: :controller do
             screen_name:           "dio",
             email:                 "the-world-21@somewhere.everywhere.now",
             password:              "AReallySecurePassword456!",
-            password_confirmation: "AReallySecurePassword456!"
-          }
+            password_confirmation: "AReallySecurePassword456!",
+          },
         }
       end
 
@@ -59,6 +60,7 @@ describe User::RegistrationsController, type: :controller do
     context "invalid user sign up" do
       before do
         allow(APP_CONFIG).to receive(:dig).with(:hcaptcha, :enabled).and_return(false)
+        allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(true)
       end
 
       subject { post :create, params: registration_params }
@@ -70,8 +72,8 @@ describe User::RegistrationsController, type: :controller do
               screen_name:           "",
               email:                 "",
               password:              "",
-              password_confirmation: ""
-            }
+              password_confirmation: "",
+            },
           }
         end
 
@@ -87,8 +89,8 @@ describe User::RegistrationsController, type: :controller do
               screen_name:           "Dio Brando",
               email:                 "the-world-21@somewhere.everywhere.now",
               password:              "AReallySecurePassword456!",
-              password_confirmation: "AReallySecurePassword456!"
-            }
+              password_confirmation: "AReallySecurePassword456!",
+            },
           }
         end
 
@@ -104,14 +106,42 @@ describe User::RegistrationsController, type: :controller do
               screen_name:           "moderator",
               email:                 "the-world-21@somewhere.everywhere.now",
               password:              "AReallySecurePassword456!",
-              password_confirmation: "AReallySecurePassword456!"
-            }
+              password_confirmation: "AReallySecurePassword456!",
+            },
           }
         end
 
         it "does not create a user" do
           expect { subject }.not_to(change { User.count })
         end
+      end
+    end
+
+    context "when registrations are disabled" do
+      before do
+        allow(APP_CONFIG).to receive(:dig).with(:hcaptcha, :enabled).and_return(false)
+        allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(false)
+      end
+
+      it "redirects to the root page" do
+        subject
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "#new" do
+    subject { get :new }
+
+    context "when registrations are disabled" do
+      before do
+        allow(APP_CONFIG).to receive(:dig).with(:hcaptcha, :enabled).and_return(false)
+        allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(false)
+      end
+
+      it "redirects to the root page" do
+        subject
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/views/about/index.html.haml_spec.rb
+++ b/spec/views/about/index.html.haml_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "about/index.html.haml", type: :view do
+  before do
+    stub_const("APP_CONFIG", {
+                 "hostname" => "example.com",
+                 "https"    => true,
+                 "sitename" => "yastask",
+               },)
+  end
+
+  subject(:rendered) { render }
+
+  context "registrations are enabled" do
+    before do
+      allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(true)
+    end
+
+    it "has references to registering now" do
+      expect(rendered).to match(/Register now/)
+    end
+  end
+
+  context "registrations are disabled" do
+    before do
+      allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(false)
+    end
+
+    it "has no references to registering now" do
+      expect(rendered).to_not match(/Register now/)
+    end
+  end
+end

--- a/spec/views/navigation/_guest.html.haml_spec.rb
+++ b/spec/views/navigation/_guest.html.haml_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "navigation/_guest.html.haml", type: :view do
+  subject(:rendered) do
+    render partial: "navigation/guest"
+  end
+
+  context "registrations are enabled" do
+    before do
+      allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(true)
+    end
+
+    it "has a sign up link" do
+      expect(rendered).to match(/Sign up/)
+    end
+  end
+
+  context "registrations are disabled" do
+    before do
+      allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(false)
+    end
+
+    it "has no sign up link" do
+      expect(rendered).to_not match(/Sign up/)
+    end
+  end
+end


### PR DESCRIPTION
A little present to the people that decide to host Retrospring themselves.

This is handled via a new configuration option in `justask.yml`:

```yaml
features:
  registration:
    enabled: true
```

Removes all mentions of signing up from the interface (I hope) and redirects away from the sign up/user creation routes if they are tried to be accessed.

----

**Important:** This doesn't come with an invite system, so to create users you either temporarily enable registrations again, or create them manually over RailsAdmin.