### PR TITLE
Remove fetching of HOSTNAME env variable

### DIFF
--- a/lib/retrospring/config.rb
+++ b/lib/retrospring/config.rb
@@ -13,8 +13,6 @@ module Retrospring
       env_config = {
         # The site name, shown everywhere
         site_name: ENV.fetch("SITE_NAME", nil),
-
-        hostname:  ENV.fetch("HOSTNAME", nil),
       }.compact
       hash.merge!(env_config)
 


### PR DESCRIPTION
If running in Docker, or a server that has the `HOSTNAME` env variable set, this always takes precedence over the `justask.yml` hostname setting, which is used for the building of URLs in mails.

This causes mails to contain URLs for confirmations that look something like this, which is obviously broken:
```
https://6a933592adad/user/confirmations...
```

This Pull Request removes env fetching for `HOSTNAME` to the `hostname` YAML setting for now, to prevent issues with new instances being set up.