### PR TITLE
Make site tagline configurable

### DIFF
--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -4,7 +4,7 @@
     .card-body.py-4
       = render "layouts/messages"
       %h1= APP_CONFIG["site_name"]
-      %p= t(".subtitle")
+      %p= APP_CONFIG["site_tagline"]
       - if Retrospring::Config.registrations_enabled?
         %p
           %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_registration_path) }

--- a/config/justask.yml.example
+++ b/config/justask.yml.example
@@ -1,6 +1,9 @@
 # The site name, shown everywhere.
 site_name: "justask"
 
+# The sites tagline, shown on the start page
+site_tagline: "Ask questions, give answers and learn more about your friends."
+
 # Use the SVG logo from `/public/logo.svg`
 use_svg_logo: false
 

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -2,7 +2,6 @@ en:
   language: "English"
   about:
     index:
-      subtitle: "Ask questions, give answers and learn more about your friends."
       register: "Register now"
       already_member: "Already a member?"
       more_features: "But wait, there's more!"


### PR DESCRIPTION
More customization for self-hosted instances, allowing the tagline on the start page to differ from the default "Ask questions, give answers and learn more about your friends."

Example:
![image](https://github.com/user-attachments/assets/5037e26c-a112-421f-9420-4e0e1b72b200)
