### PR TITLE
Add advanced frontpage layout config option

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -2,9 +2,9 @@
 
 class AboutController < ApplicationController
   def index
-    if Retrospring::Config.advanced_frontpage_enabled?
-      render template: "about/index_advanced"
-    end
+    return unless Retrospring::Config.advanced_frontpage_enabled?
+
+    render template: "about/index_advanced"
   end
 
   def about

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class AboutController < ApplicationController
-  def index; end
+  def index
+    if Retrospring::Config.advanced_frontpage_enabled?
+      render template: "about/index_advanced"
+    end
+  end
 
   def about
     @users = Rails.cache.fetch("about_count_users", expires_in: 1.hour) { user_count - current_ban_count }

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -1,95 +1,32 @@
-- provide(:title, APP_CONFIG["site_name"])
 .container
-  .card.bg-primary.my-3.text-bg-primary.text-center
-    .card-body.py-4
-      = render "layouts/messages"
-      %h1= APP_CONFIG["site_name"]
-      %p= APP_CONFIG["site_tagline"]
-      - if Retrospring::Config.registrations_enabled?
-        %p
-          %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_registration_path) }
-            = t(".register")
-        %small
-          = t(".already_member")
-          = link_to t("voc.login"), new_user_session_path
-      - else
-        %p
-          %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_session_path) }
-            = t("voc.login")
+  .py-3.py-sm-5
+    .row.d-sm-flex
+      .col-md-8.align-self-center.text-center.text-md-start
+        %h1
+          - if APP_CONFIG["use_svg_logo"]
+            .d-inline-block.w-50
+              = render inline: Rails.application.config.justask_svg_logo
+          - else
+            = APP_CONFIG["site_name"]
+          - if Rails.env.development?
+            %span.badge.rounded-pill.bg-warning.text-bg-warning
+              DEV
+        %p.lead= APP_CONFIG["site_tagline"]
+      .col-md-4
+        %a.btn.btn-primary.d-grid{ href: url_for(new_user_registration_path) }
+          = t("voc.register_now")
+        .d-block.text-center.py-2.text-secondary
+          = t(".or")
+        .card
+          .card-body
+            = bootstrap_form_for(User.new, as: :user, url: session_path(:user), data: { turbo: false }) do |f|
 
-  .row.my-5.my-sm-10
-    .col-sm-6.order-5.order-sm-1.text-center.text-sm-right
-      %h2.mb-4= t(".questions.header")
-      = t(".questions.body_html", app_name: APP_CONFIG["site_name"])
-    .col-sm-6.order-1.order-sm-5
-      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
-        %i.fa.fa-envelope.align-self-center.mb-5.mb-sm-0
+              = f.text_field :login, autofocus: true, autocomplete: :username
+              = f.password_field :password, autocomplete: "current-password"
 
-  .row.my-5.my-sm-10
-    .col-sm-6
-      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
-        %i.fa.fa-comments.align-self-center.mb-5.mb-sm-0
-    .col-sm-6.text-center.text-sm-left
-      %h2.mb-4= t(".discussions.header")
-      = t(".discussions.body_html", app_name: APP_CONFIG["site_name"])
+              - if Devise.mappings[:user].rememberable?
+                = f.check_box :remember_me
 
-  .row.my-5.my-sm-10
-    .col-sm-6.order-5.order-sm-1.text-center.text-sm-right
-      %h2.mb-4= t(".share.header")
-      = t(".share.body_html", app_name: APP_CONFIG["site_name"])
-    .col-sm-6.order-1.order-sm-5
-      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
-        %i.fa.fa-share.align-self-center.mb-5.mb-sm-0
-
-  .row.my-5.my-sm-10
-    .col-sm-6
-      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
-        %i.fa.fa-paint-brush.align-self-center.mb-5.mb-sm-0
-    .col-sm-6.text-center.text-sm-left
-      %h2.mb-4= t(".customize.header")
-      = t(".customize.body_html", app_name: APP_CONFIG["site_name"])
-      .card
-        .card-body
-          .row.mx-n2
-            .col.px-2
-              .d-grid
-                %button.btn.btn-success.js-theme-button{ data: { theme: "theme-success" } }= t(".customize.themes.green")
-            .col.px-2
-              .d-grid
-                %button.btn.btn-warning.js-theme-button{ data: { theme: "theme-warning" } }= t(".customize.themes.orange")
-            .col.px-2
-              .d-grid
-                %button.btn.btn-danger.js-theme-button{ data: { theme: "theme-danger" } }= t(".customize.themes.red")
-            .col.px-2
-              .d-grid
-                %button.btn.btn-default.js-theme-button{ data: { theme: "reset" } }= t(".customize.themes.reset")
-
-.container.text-center
-  %h2.mb-4= t(".more_features")
-  .row.my-5
-    .col-sm-4
-      %h3.mb-3
-        %i.fa.fa-fw.fa-globe.text-primary
-        = t(".open_source.header")
-      %p= t(".open_source.body", app_name: APP_CONFIG["site_name"])
-    .col-sm-4
-      %h3.mb-3
-        %i.fa.fa-fw.fa-eye-slash.text-primary
-        = t(".no_ads.header")
-      %p= t(".no_ads.body")
-    .col-sm-4
-      %h3.mb-3
-        %i.fa.fa-fw.fa-user-secret.text-primary
-        = t(".your_data.header")
-      %p= t(".your_data.body", app_name: APP_CONFIG["site_name"])
-
-  - if APP_CONFIG.dig(:features, :registration, :enabled)
-    .card
-      .card-body
-        %h2= t(".prompt.header")
-        %p= t(".prompt.body")
-        %p
-          %a.btn.btn-primary.btn-lg{ href: url_for(new_user_registration_path) }
-            = t(".register")
-
-= render "shared/links"
+              = f.primary t("voc.login"), class: "btn btn-primary d-grid w-100"
+  
+  = render "shared/links"

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -13,10 +13,11 @@
               DEV
         %p.lead= APP_CONFIG["site_tagline"]
       .col-md-4
-        %a.btn.btn-primary.d-grid{ href: url_for(new_user_registration_path) }
-          = t("voc.register_now")
-        .d-block.text-center.py-2.text-secondary
-          = t(".or")
+        - if Retrospring::Config.registrations_enabled?
+          %a.btn.btn-primary.d-grid{ href: url_for(new_user_registration_path) }
+            = t("voc.register_now")
+          .d-block.text-center.py-2.text-secondary
+            = t(".or")
         .card
           .card-body
             = bootstrap_form_for(User.new, as: :user, url: session_path(:user), data: { turbo: false }) do |f|

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -28,5 +28,5 @@
                 = f.check_box :remember_me
 
               = f.primary t("voc.login"), class: "btn btn-primary d-grid w-100"
-  
+
   = render "shared/links"

--- a/app/views/about/index_advanced.html.haml
+++ b/app/views/about/index_advanced.html.haml
@@ -1,0 +1,95 @@
+- provide(:title, APP_CONFIG["site_name"])
+.container
+  .card.bg-primary.my-3.text-bg-primary.text-center
+    .card-body.py-4
+      = render "layouts/messages"
+      %h1= APP_CONFIG["site_name"]
+      %p= APP_CONFIG["site_tagline"]
+      - if Retrospring::Config.registrations_enabled?
+        %p
+          %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_registration_path) }
+            = t("voc.register_now")
+        %small
+          = t(".already_member")
+          = link_to t("voc.login"), new_user_session_path
+      - else
+        %p
+          %a.btn.btn-outline-light.btn-lg{ href: url_for(new_user_session_path) }
+            = t("voc.login")
+
+  .row.my-5.my-sm-10
+    .col-sm-6.order-5.order-sm-1.text-center.text-sm-right
+      %h2.mb-4= t(".questions.header")
+      = t(".questions.body_html", app_name: APP_CONFIG["site_name"])
+    .col-sm-6.order-1.order-sm-5
+      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
+        %i.fa.fa-envelope.align-self-center.mb-5.mb-sm-0
+
+  .row.my-5.my-sm-10
+    .col-sm-6
+      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
+        %i.fa.fa-comments.align-self-center.mb-5.mb-sm-0
+    .col-sm-6.text-center.text-sm-left
+      %h2.mb-4= t(".discussions.header")
+      = t(".discussions.body_html", app_name: APP_CONFIG["site_name"])
+
+  .row.my-5.my-sm-10
+    .col-sm-6.order-5.order-sm-1.text-center.text-sm-right
+      %h2.mb-4= t(".share.header")
+      = t(".share.body_html", app_name: APP_CONFIG["site_name"])
+    .col-sm-6.order-1.order-sm-5
+      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
+        %i.fa.fa-share.align-self-center.mb-5.mb-sm-0
+
+  .row.my-5.my-sm-10
+    .col-sm-6
+      .text-center.text-primary.d-flex.h-100.justify-content-center.fs-10
+        %i.fa.fa-paint-brush.align-self-center.mb-5.mb-sm-0
+    .col-sm-6.text-center.text-sm-left
+      %h2.mb-4= t(".customize.header")
+      = t(".customize.body_html", app_name: APP_CONFIG["site_name"])
+      .card
+        .card-body
+          .row.mx-n2
+            .col.px-2
+              .d-grid
+                %button.btn.btn-success.js-theme-button{ data: { theme: "theme-success" } }= t(".customize.themes.green")
+            .col.px-2
+              .d-grid
+                %button.btn.btn-warning.js-theme-button{ data: { theme: "theme-warning" } }= t(".customize.themes.orange")
+            .col.px-2
+              .d-grid
+                %button.btn.btn-danger.js-theme-button{ data: { theme: "theme-danger" } }= t(".customize.themes.red")
+            .col.px-2
+              .d-grid
+                %button.btn.btn-default.js-theme-button{ data: { theme: "reset" } }= t(".customize.themes.reset")
+
+.container.text-center
+  %h2.mb-4= t(".more_features")
+  .row.my-5
+    .col-sm-4
+      %h3.mb-3
+        %i.fa.fa-fw.fa-globe.text-primary
+        = t(".open_source.header")
+      %p= t(".open_source.body", app_name: APP_CONFIG["site_name"])
+    .col-sm-4
+      %h3.mb-3
+        %i.fa.fa-fw.fa-eye-slash.text-primary
+        = t(".no_ads.header")
+      %p= t(".no_ads.body")
+    .col-sm-4
+      %h3.mb-3
+        %i.fa.fa-fw.fa-user-secret.text-primary
+        = t(".your_data.header")
+      %p= t(".your_data.body", app_name: APP_CONFIG["site_name"])
+
+  - if APP_CONFIG.dig(:features, :registration, :enabled)
+    .card
+      .card-body
+        %h2= t(".prompt.header")
+        %p= t(".prompt.body")
+        %p
+          %a.btn.btn-primary.btn-lg{ href: url_for(new_user_registration_path) }
+            = t(".register")
+
+= render "shared/links"

--- a/config/justask.yml.example
+++ b/config/justask.yml.example
@@ -58,6 +58,9 @@ features:
   # Registrations
   registration:
     enabled: true
+  # Advanced (marketing) frontpage layout
+  advanced_frontpage:
+    enabled: false
 
 # Redis
 redis_url: "redis://localhost:6379"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -2,7 +2,8 @@ en:
   language: "English"
   about:
     index:
-      register: "Register now"
+      or: "or"
+    index_advanced:
       already_member: "Already a member?"
       more_features: "But wait, there's more!"
       questions:

--- a/config/locales/voc.en.yml
+++ b/config/locales/voc.en.yml
@@ -24,6 +24,7 @@ en:
     subscribe: "Subscribe"
     unsubscribe: "Unsubscribe"
     register: "Sign up"
+    register_now: "Register now"
     remove: "Remove"
     report: "Report"
     terms: "Terms of Service"

--- a/lib/retrospring/config.rb
+++ b/lib/retrospring/config.rb
@@ -23,5 +23,7 @@ module Retrospring
     end
 
     def registrations_enabled? = APP_CONFIG.dig(:features, :registration, :enabled)
+
+    def advanced_frontpage_enabled? = APP_CONFIG.dig(:features, :advanced_frontpage, :enabled)
   end
 end

--- a/spec/controllers/about_controller_spec.rb
+++ b/spec/controllers/about_controller_spec.rb
@@ -3,6 +3,32 @@
 require "rails_helper"
 
 describe AboutController, type: :controller do
+  describe "#index" do
+    subject { get :index }
+
+    context "advanced layout is enabled" do
+      before do
+        allow(APP_CONFIG).to receive(:dig).with(:features, :advanced_frontpage, :enabled).and_return(true)
+      end
+
+      it "renders the correct template" do
+        subject
+        expect(response).to render_template("about/index_advanced")
+      end
+    end
+
+    context "advanced layout is disabled" do
+      before do
+        allow(APP_CONFIG).to receive(:dig).with(:features, :advanced_frontpage, :enabled).and_return(false)
+      end
+
+      it "renders the correct template" do
+        subject
+        expect(response).to render_template("about/index")
+      end
+    end
+  end
+
   describe "#about" do
     subject { get :about }
 

--- a/spec/views/about/index_advanced.html.haml_spec.rb
+++ b/spec/views/about/index_advanced.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "about/index.html.haml", type: :view do
+describe "about/index_advanced.html.haml", type: :view do
   before do
     stub_const("APP_CONFIG", {
                  "hostname" => "example.com",


### PR DESCRIPTION
The current frontpage is mostly for "marketing" purposes, displaying all the different features Retrospring has. This isn't really required for self-hosted instances. So this Pull Request adds a by default enabled simple layout.

The configuration option added for this is the following:
```yaml
features:
  # Advanced (marketing) frontpage layout
  advanced_frontpage:
    enabled: false
```

| Mobile layout | Desktop layout |
|---------------|----------------|
|![image](https://github.com/user-attachments/assets/759e93d5-e373-4706-beca-5715683f143c)|![image](https://github.com/user-attachments/assets/592158a7-afd9-446e-b870-ee6f38ec6bd0)|