### PR TITLE
Add customizable source URL

### DIFF
--- a/app/views/shared/_links.html.haml
+++ b/app/views/shared/_links.html.haml
@@ -5,7 +5,7 @@
   ·
   = link_to t(".about"), about_path
   ·
-  = link_to t(".source"), "https://github.com/Retrospring/retrospring"
+  = link_to t(".source"), Retrospring::Version.source_url
   ·
   = link_to t(".terms"), terms_path
   ·

--- a/config/justask.yml.example
+++ b/config/justask.yml.example
@@ -108,3 +108,6 @@ sentry_dsn: ''
 #  sso: "CANNY_SSO_TOKEN_HERE"
 #  feature_board: "CANNY_FEATURE_BOARD_TOKEN"
 #  bug_board: "CANNY_BUGS_BOARD_TOKEN"
+
+# If you run a fork, please uncomment and adjust this url!
+# source_url: "https://github.com/retrospring/retrospring"

--- a/lib/retrospring/version.rb
+++ b/lib/retrospring/version.rb
@@ -25,7 +25,7 @@ module Retrospring
 
     def minor = [month.to_s.rjust(2, "0"), day.to_s.rjust(2, "0")].join
 
-    def source_url = APP_CONFIG.dig(:source_url) || "https://github.com/retrospring/retrospring"
+    def source_url = APP_CONFIG[:source_url] || "https://github.com/retrospring/retrospring"
 
     def to_a = [year.to_s, minor, patch.to_s]
 

--- a/lib/retrospring/version.rb
+++ b/lib/retrospring/version.rb
@@ -25,6 +25,8 @@ module Retrospring
 
     def minor = [month.to_s.rjust(2, "0"), day.to_s.rjust(2, "0")].join
 
+    def source_url = APP_CONFIG.dig(:source_url) || "https://github.com/retrospring/retrospring"
+
     def to_a = [year.to_s, minor, patch.to_s]
 
     def to_s = [to_a.join("."), suffix].join

--- a/spec/views/about/index_advanced.html.haml_spec.rb
+++ b/spec/views/about/index_advanced.html.haml_spec.rb
@@ -13,6 +13,10 @@ describe "about/index_advanced.html.haml", type: :view do
 
   subject(:rendered) { render }
 
+  before do
+    allow(APP_CONFIG).to receive(:dig).and_call_original
+  end
+
   context "registrations are enabled" do
     before do
       allow(APP_CONFIG).to receive(:dig).with(:features, :registration, :enabled).and_return(true)


### PR DESCRIPTION
If people run forks, adjusting the URL in the template isn't that hard, this just makes it easier to customize this URL.