### PR TITLE
Rename `deleted` field to `resolved` in Reports

### DIFF
--- a/app/controllers/ajax/moderation_controller.rb
+++ b/app/controllers/ajax/moderation_controller.rb
@@ -7,7 +7,7 @@ class Ajax::ModerationController < AjaxController
     report = Report.find(params[:id])
 
     begin
-      report.deleted = true
+      report.resolved = true
       report.save
     rescue => e
       Sentry.capture_exception(e)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
     @has_new_reports = if current_user.last_reports_visit.nil?
                          true
                        else
-                         Report.where(deleted: false)
+                         Report.where(resolved: false)
                                .where("created_at > ?", current_user.last_reports_visit)
                                .count.positive?
                        end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -49,7 +49,7 @@ class Answer < ApplicationRecord
     rep = Report.where(target_id: self.id, type: 'Reports::Answer')
     rep.each do |r|
       unless r.nil?
-        r.deleted = true
+        r.resolved = true
         r.save
       end
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -16,7 +16,7 @@ class Comment < ApplicationRecord
     rep = Report.where(target_id: self.id, type: 'Reports::Comment')
     rep.each do |r|
       unless r.nil?
-        r.deleted = true
+        r.resolved = true
         r.save
       end
     end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -17,7 +17,7 @@ class Question < ApplicationRecord
     rep = Report.where(target_id: self.id, type: "Reports::Question")
     rep.each do |r|
       unless r.nil?
-        r.deleted = true
+        r.resolved = true
         r.save
       end
     end

--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -18,7 +18,7 @@ class ReportFilter
   end
 
   def results
-    scope = Report.where(deleted: false)
+    scope = Report.where(resolved: false)
                   .order(:created_at)
                   .reverse_order
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,7 +84,7 @@ class User < ApplicationRecord
   before_destroy do
     Report.where(target_id: id, type: "Reports::User").find_each do |r|
       unless r.nil?
-        r.deleted = true
+        r.resolved = true
         r.save
       end
     end
@@ -156,7 +156,7 @@ class User < ApplicationRecord
                     object.user
                   end
 
-    existing = Report.find_by(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, deleted: false)
+    existing = Report.find_by(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, resolved: false)
     if existing.nil?
       Report.create(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, reason:)
     elsif !reason.nil? && reason.length.positive?

--- a/db/migrate/20250301170817_rename_deleted_to_resolved_reports.rb
+++ b/db/migrate/20250301170817_rename_deleted_to_resolved_reports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameDeletedToResolvedReports < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :reports, :deleted, :resolved
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_01_203930) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_01_170817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -171,7 +171,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_203930) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.boolean "deleted", default: false
+    t.boolean "resolved", default: false
     t.string "reason"
     t.bigint "target_user_id"
     t.index ["target_user_id"], name: "index_reports_on_target_user_id"
@@ -186,7 +186,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_203930) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
-    t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
+    t.index ["resource_type", "resource_id"], name: "index_roles_on_resource_type_and_resource_id"
   end
 
   create_table "rpush_apps", force: :cascade do |t|
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_203930) do
     t.string "client_id"
     t.string "client_secret"
     t.string "access_token"
-    t.datetime "access_token_expiration", precision: nil
+    t.datetime "access_token_expiration"
     t.text "apn_key"
     t.string "apn_key_id"
     t.string "team_id"
@@ -393,5 +393,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_203930) do
     t.index ["user_id"], name: "index_web_push_subscriptions_on_user_id"
   end
 
+  add_foreign_key "anonymous_blocks", "users", column: "target_user_id"
   add_foreign_key "profiles", "users"
 end

--- a/spec/controllers/ajax/moderation_controller_spec.rb
+++ b/spec/controllers/ajax/moderation_controller_spec.rb
@@ -58,8 +58,8 @@ describe Ajax::ModerationController, :ajax_controller, type: :controller do
         expect { subject }.to_not(change { Report.count })
       end
 
-      it "only marks the report as deleted" do
-        expect { subject }.to(change { report.reload.deleted }.from(false).to(true))
+      it "only marks the report as resolved" do
+        expect { subject }.to(change { report.reload.resolved }.from(false).to(true))
       end
 
       include_examples "returns the expected response"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe User, type: :model do
         other_user.report me, "va tutto benissimo"
 
         expect { me.destroy }
-          .to change { Reports::User.find_by(target_id: me.id).deleted? }
+          .to change { Reports::User.find_by(target_id: me.id).resolved? }
           .from(false)
           .to(true)
       end


### PR DESCRIPTION
We don't even have soft deletes, so naming the field `deleted` doesn't make much sense.