### PR TITLE
Remove logic to append reasons to existing reports

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -8,12 +8,4 @@ class Report < ApplicationRecord
   def target
     type.sub('Reports::', '').constantize.where(id: target_id).first
   end
-
-  def append_reason(new_reason)
-    if reason.nil?
-      update(reason: new_reason)
-    else
-      update(reason: [reason || "", new_reason].join("\n"))
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,8 +159,6 @@ class User < ApplicationRecord
     existing = Report.find_by(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, resolved: false)
     if existing.nil?
       Report.create(type: "Reports::#{object.class}", target_id: object.id, user_id: id, target_user_id: target_user&.id, reason:)
-    elsif !reason.nil? && reason.length.positive?
-      existing.append_reason(reason)
     end
   end
   # endregion


### PR DESCRIPTION
Previously, multiple reports on the same object caused the reasons to be appended (if one actually was supplied). This however was massively confusing in the reporting interface with gibberish reporting reasons. This PR removes the "appending reasons" behaviour, but only allows one report per object per user.