### PR TITLE
Add detail view for reports

### DIFF
--- a/app/controllers/moderation/reports_controller.rb
+++ b/app/controllers/moderation/reports_controller.rb
@@ -18,6 +18,10 @@ class Moderation::ReportsController < ApplicationController
     end
   end
 
+  def show
+    @report = Report.find(params[:id])
+  end
+
   private
 
   def filter_params

--- a/app/views/moderation/reports/show.html.haml
+++ b/app/views/moderation/reports/show.html.haml
@@ -1,0 +1,3 @@
+= render "moderation/moderationbox", report: @report
+
+- parent_layout "moderation"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     post "/moderation/unmask", to: "moderation#toggle_unmask", as: :moderation_toggle_unmask
     get "/moderation/blocks", to: "moderation/anonymous_block#index", as: :mod_anon_block_index
     get "/moderation/inbox/:user", to: "moderation/inbox#index", as: :mod_inbox_index
+    get "/moderation/report/:id", to: "moderation/reports#show", as: :moderation_report
     get "/moderation/reports(/:type)", to: "moderation/reports#index", as: :moderation_reports
     get "/moderation/questions/:author_identifier", to: "moderation/questions#show", as: :moderation_questions
     namespace :ajax do

--- a/spec/controllers/moderation/reports_controller_spec.rb
+++ b/spec/controllers/moderation/reports_controller_spec.rb
@@ -118,4 +118,43 @@ describe Moderation::ReportsController, type: :controller do
       end
     end
   end
+
+  describe "#show" do
+    shared_examples_for "sets the expected ivars" do
+      let(:expected_assigns) { {} }
+
+      it "sets the expected ivars" do
+        subject
+
+        expected_assigns.each do |name, value|
+          expect(assigns[name]).to eq(value)
+        end
+      end
+    end
+
+    context "template rendering" do
+      let(:other_user) { FactoryBot.create :user }
+      let(:report) { Report.create(user:, target_id: other_user.id, type: "Reports::User") }
+
+      subject { get :show, params: { id: report.id } }
+
+      before do
+        report
+        sign_in user
+      end
+
+      it "renders the moderation/reports/show template" do
+        subject
+        expect(response).to render_template("moderation/reports/show")
+      end
+
+      include_examples "sets the expected ivars" do
+        let(:expected_assigns) do
+          {
+            report:
+          }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Tiny new controller action, displaying a single report.

![image](https://github.com/user-attachments/assets/a8e7dbb5-b74f-47dd-ae12-c732429514de)

_Prerequisite change to add email sending for new reports (so that they can be actually linked)_